### PR TITLE
Relax website URL validation to match frontend regex

### DIFF
--- a/src/controllers/audit.ts
+++ b/src/controllers/audit.ts
@@ -8,7 +8,14 @@ import auditRequestsService, { AuditRequestRecord } from '../services/audit-requ
 const auditSchema = z.object({
     name: z.string().min(1).max(200),
     email: z.string().email().max(254),
-    websiteUrl: z.string().url().max(2048),
+    websiteUrl: z
+        .string()
+        .trim()
+        .max(2048)
+        .regex(
+            /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(\/[\S]*)?$/i,
+            'Enter a valid website URL (e.g. yourbusiness.com).'
+        ),
     phoneNumber: z.string().optional(),
     specifics: z
         .union([z.string(), z.array(z.string())])

--- a/src/controllers/leads.ts
+++ b/src/controllers/leads.ts
@@ -20,7 +20,16 @@ const leadsSchema = z.object({
         .array(z.enum(['web-design', 'seo', 'unsure']))
         .min(1)
         .optional(),
-    currentWebsite: z.string().url().optional().or(z.literal('')),
+    currentWebsite: z
+        .string()
+        .trim()
+        .max(2048)
+        .regex(
+            /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(\/[\S]*)?$/i,
+            'Enter a valid website URL (e.g. yourbusiness.com).'
+        )
+        .optional()
+        .or(z.literal('')),
     improvements: z.array(z.string().min(1).max(200)).min(1).max(20),
     briefSummary: z.string().max(2000).optional(),
     promoCode: z


### PR DESCRIPTION
## Summary

The marketing site's frontend regex was loosened to accept a wider range of natural user inputs (bare domains, paths, non-www subdomains). This PR loosens the backend validation to match, so frontend-valid submissions stop getting rejected by the server.

## What Changed

Two Zod schema fields updated with the same validation rules as \`lib/validation/url.ts\` on the marketing site repo:

| File | Field | Required? |
|------|-------|-----------|
| \`src/controllers/leads.ts\` | \`currentWebsite\` | Optional — preserved \`.optional().or(z.literal(''))\` semantics |
| \`src/controllers/audit.ts\` | \`websiteUrl\` | Required |

### New rules (both fields)

\`\`\`typescript
z.string()
  .trim()
  .max(2048)
  .regex(
    /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(\/[\S]*)?$/i,
    'Enter a valid website URL (e.g. yourbusiness.com).'
  )
\`\`\`

### Accepts (previously rejected)

- \`example.com\`
- \`https://example.com\`
- \`app.example.com\`
- \`example.com/contact?ref=foo\`

### Still rejects

- \`notaurl\` (no dot)
- \`foo.\` (no TLD)
- \`123\` (no domain)
- TLDs shorter than 2 chars

## Out of Scope

- No server-side normalization (frontend already calls \`normalizeWebsiteUrl()\` and prepends \`https://\` when missing)
- No other URL fields, no other endpoints
- \`no tests exist\` for these endpoints in the server repo — nothing to update or break

## Test Plan

- [x] TypeScript compiles cleanly
- [ ] POST \`/api/leads\` with \`currentWebsite: \"example.com\"\` → accepts
- [ ] POST \`/api/leads\` with \`currentWebsite: \"\"\` → accepts (empty string)
- [ ] POST \`/api/leads\` without \`currentWebsite\` → accepts (optional)
- [ ] POST \`/api/leads\` with \`currentWebsite: \"notaurl\"\` → 400 with the new error message
- [ ] POST \`/api/audit\` with \`websiteUrl: \"example.com/contact?ref=foo\"\` → accepts
- [ ] POST \`/api/audit\` with \`websiteUrl: \"https://example.com\"\` → accepts
- [ ] POST \`/api/audit\` with \`websiteUrl: \"notaurl\"\` → 400 with the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)