### PR TITLE
Standardize honeypot field name to 'honeypot' on /api/leads

### DIFF
--- a/src/controllers/leads.ts
+++ b/src/controllers/leads.ts
@@ -38,7 +38,7 @@ const leadsSchema = z.object({
         .max(32)
         .optional()
         .transform(v => (v && v.length > 0 ? v : undefined)),
-    website_confirm: z.string().optional(), // honeypot
+    honeypot: z.string().optional(),
 })
 
 const DISCORD_USERNAME = 'PixelVerse Lead Alerts'
@@ -108,7 +108,7 @@ const createLead = async (req: Request, res: Response): Promise<Response> => {
         const parsed = leadsSchema.parse(req.body)
 
         // Honeypot: return 200 silently to not tip off bots
-        if (parsed.website_confirm) {
+        if (parsed.honeypot) {
             return res.status(200).json({ message: 'Message received.' })
         }
 


### PR DESCRIPTION
## Summary

Rename the honeypot field on \`/api/leads\` from \`website_confirm\` to \`honeypot\` so it matches \`/api/audit\` and the payload the marketing site frontend is already sending.

## Why

The frontend recently started sending \`honeypot: data.website_confirm ?? ''\` to \`/api/leads\`. The server's Zod schema only accepted \`website_confirm\`. Since Zod's default \`.object()\` strips unknown keys, the frontend's \`honeypot\` field was being silently dropped and the bot-detection only worked if the frontend ALSO happened to send the legacy \`website_confirm\` key.

Same class of silent-drop bug we already cleaned up for \`currentWebsite\`/\`briefSummary\`/\`promoCode\`.

## Changes

\`src/controllers/leads.ts\` — two identical edits:

1. Schema: \`website_confirm: z.string().optional()\` → \`honeypot: z.string().optional()\`
2. Handler: \`if (parsed.website_confirm)\` → \`if (parsed.honeypot)\`

Behavior is unchanged: same optional string, same silent-200 pattern when truthy, same skipped pipeline.

## Frontend Coordination Required

The marketing site's leads form must send \`honeypot\` (not \`website_confirm\`) in the POST body. A follow-up frontend change is needed to match.

## Test Plan

- [x] TypeScript compiles cleanly
- [ ] POST /api/leads with \`honeypot: \"\"\` or no honeypot → normal flow (DB insert + Discord)
- [ ] POST /api/leads with \`honeypot: \"anything\"\` → 200 silent, no DB insert, no Discord
- [ ] POST /api/leads with legacy \`website_confirm: \"anything\"\` → **unknown key, stripped by Zod, normal flow runs** (this is a breaking change for old frontend code — flagged below)

## Breaking Change Note

Before this PR: sending \`website_confirm: \"spam\"\` would trigger the honeypot.
After this PR: that field is silently stripped and the request passes normally.

Safe as long as the frontend is updated in the same deploy window. If the frontend takes longer to ship, consider holding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)