### PR TITLE
DEV-701: Deploy-window resilience for /api/deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ DOMANI_SUPABASE_SERVICE_KEY=your-domani-service-role-key
 # Generate with: openssl rand -hex 32
 BLAST_SECRET=your-secret-here
 
+# Webhook processor — set to "false" on all but one instance when
+# horizontally scaling the API (prevents multiple instances from racing
+# on the same pending_webhook_events rows). Defaults to true.
+WEBHOOK_PROCESSOR_ENABLED=true
+
 # Cloudflare R2 storage (for CMS image uploads)
 # Get these from: Cloudflare Dashboard → R2 → Manage R2 API Tokens
 R2_ACCOUNT_ID=your-cloudflare-account-id

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist
 config.ts
 /repomix-output.txt
 .mcp.json
-supabase/.temp/
+supabase/.temp/.claude/

--- a/docs/audits/webhook-durability-audit.md
+++ b/docs/audits/webhook-durability-audit.md
@@ -1,0 +1,82 @@
+# Webhook Durability Audit (DEV-701)
+
+**Date:** 2026-04-14
+**Trigger:** [DEV-701](https://linear.app/pixelverse-studios/issue/DEV-701) — follow-up to the CMS expansion 504 incident where a client deploy summary was dropped during our deploy window.
+
+## Purpose
+
+For each public-facing webhook endpoint, determine:
+
+1. How does the sender behave on failure? (retries, backoff, give-up)
+2. What happens today if the endpoint is down during a deploy window?
+3. Is the payload **recoverable** (sender can re-trigger) or **irrecoverable** (one-shot, lost if dropped)?
+4. Does it warrant a durable-queue mechanism?
+
+## Endpoints in Scope
+
+### 1. `POST /api/deployments` — client website CI/CD
+
+| Question | Answer |
+|---|---|
+| Sender | GitHub Actions / Netlify post-deploy scripts in each client repo |
+| Retries on failure? | **No.** Fire-and-forget `curl`. No retry, no backoff. |
+| Payload regeneration possible? | **No.** Built from the build's diff/changelog at a single point in time; the CI job completes and the build artifact is discarded. |
+| Human visibility on failure? | None. Robot-to-robot; only noticed days later when a missing email/record is caught manually. |
+| Classification | **Irrecoverable — one-shot.** |
+| Durability action | **Implemented.** Payload is inserted into `pending_webhook_events` before any fallible processing runs. In-process poller retries on 1min → 5min → 30min cadence, then marks `failed` and logs. See `src/lib/webhook-processor.ts`, `src/controllers/deployments.ts`. |
+
+### 2. `POST /api/leads/new` — public lead form
+
+| Question | Answer |
+|---|---|
+| Sender | Browser on `pixelversestudios.io` lead form |
+| Retries on failure? | No automatic retry; the form shows an error and the user can click submit again. |
+| Payload regeneration possible? | **Yes.** The user still has the form open with their data typed; they resubmit. |
+| Human visibility on failure? | The user sees the error immediately. |
+| Classification | **Recoverable.** |
+| Durability action | **Not needed.** The human in the loop is the durability mechanism. Adding a queue would introduce complexity without addressing an actual data-loss path. |
+
+### 3. `POST /api/contact-forms/*` — client website contact forms
+
+| Question | Answer |
+|---|---|
+| Sender | Browser on various client websites |
+| Retries on failure? | No automatic retry. Same UX pattern as leads form. |
+| Payload regeneration possible? | **Yes.** User has the form in front of them. |
+| Human visibility on failure? | User sees an inline error. |
+| Classification | **Recoverable.** |
+| Durability action | **Not needed.** Same rationale as leads. |
+
+### 4. `POST /api/audit-requests` — public audit form
+
+| Question | Answer |
+|---|---|
+| Sender | Browser on `pixelversestudios.io` audit request form |
+| Retries on failure? | No automatic retry. |
+| Payload regeneration possible? | **Yes.** User still has the form. |
+| Human visibility on failure? | User sees an inline error. |
+| Classification | **Recoverable.** |
+| Durability action | **Not needed.** Same rationale as leads. |
+
+### 5. `POST /api/calendly-webhook` — Calendly booking notifications
+
+| Question | Answer |
+|---|---|
+| Sender | Calendly's webhook service |
+| Retries on failure? | **Yes.** Calendly retries failed webhook deliveries on its own schedule (multiple attempts over several hours per Calendly's public docs). |
+| Payload regeneration possible? | The booking data remains in Calendly; the webhook itself is also redelivered. |
+| Human visibility on failure? | Calendly exposes webhook delivery logs in their dashboard. |
+| Classification | **Recoverable.** |
+| Durability action | **Not needed.** Calendly's own retry mechanism covers the deploy-window risk. |
+
+## Summary
+
+| Endpoint | Payload | Durability Added |
+|---|---|---|
+| `POST /api/deployments` | irrecoverable | ✅ yes — `pending_webhook_events` + in-process poller |
+| `POST /api/leads/new` | recoverable (user re-submits) | ❌ not needed |
+| `POST /api/contact-forms/*` | recoverable (user re-submits) | ❌ not needed |
+| `POST /api/audit-requests` | recoverable (user re-submits) | ❌ not needed |
+| `POST /api/calendly-webhook` | recoverable (Calendly retries) | ❌ not needed |
+
+Only one endpoint in the audit scope has a genuine irrecoverable-payload risk. Durability is implemented for that endpoint; justifications are recorded for the rest.

--- a/docs/runbooks/deploy-window.md
+++ b/docs/runbooks/deploy-window.md
@@ -1,0 +1,87 @@
+# Deploy Window Runbook
+
+**Owner:** Phil
+**Related:** [DEV-701](https://linear.app/pixelverse-studios/issue/DEV-701), [postmortem](../postmortems/2026-04-07-cms-expansion-504.md), [webhook audit](../audits/webhook-durability-audit.md)
+
+## Why this exists
+
+When our server is restarting (deploys, crashes, config changes), nothing is listening on the socket. For most endpoints that's annoying-but-recoverable (a browser user sees an error and retries). For `POST /api/deployments` it was catastrophic pre-DEV-701 because client CI/CD pipelines are fire-and-forget — the payload is dropped and cannot be reconstructed.
+
+DEV-701 added a durable queue for `/api/deployments` (see [audit](../audits/webhook-durability-audit.md)) which shrinks the window dramatically — payloads are persisted the moment the request body arrives, before any fallible processing runs. But there is still a ~1-second window during the restart where the Node process isn't accepting connections at all. This runbook covers the human-process mitigations for that residual risk.
+
+## Known client deploy windows
+
+> ⚠️ **TODO:** Fill in actual deploy windows as we learn them. Ask each client's dev contact or inspect their deploy schedule.
+
+| Client | Typical deploy window | Source |
+|---|---|---|
+| *TBD* | *TBD* | *TBD* |
+
+Until this table is filled out, treat "any weekday, business hours ET" as a possible client deploy window and schedule our own deploys accordingly.
+
+## Pre-merge checklist
+
+Before merging any PR to `main` (which triggers a production deploy on DigitalOcean App Platform):
+
+- [ ] Confirm we are **not** inside a known client deploy window (see table above).
+- [ ] Verify the current production server is healthy:
+  ```bash
+  curl -sSf https://api.pixelversestudios.io/api/clients > /dev/null && echo "OK"
+  ```
+  If that fails, investigate before adding more change on top.
+- [ ] Confirm the `pending_webhook_events` queue is empty (or at least not backed up):
+  ```sql
+  SELECT status, count(*)
+  FROM pending_webhook_events
+  WHERE created_at > now() - interval '24 hours'
+  GROUP BY status;
+  ```
+  If there's a backlog of `pending` events with `attempts > 0`, something is failing retries — debug before deploying again.
+- [ ] If the PR touches `webhook-processor`, `pending-webhook-events`, or `deployments` code paths, test locally first (see [CLAUDE.md testing protocol](../../CLAUDE.md#testing-for-claude-code-agents)).
+
+## Post-merge checklist
+
+Within 2 minutes of the merge triggering a DigitalOcean deploy:
+
+- [ ] Confirm the new deploy finished and the server is accepting traffic:
+  ```bash
+  curl -sSf https://api.pixelversestudios.io/api/clients > /dev/null && echo "OK"
+  ```
+- [ ] Confirm the webhook processor started (check DO runtime logs for `🚀 webhook-processor started`).
+- [ ] Tail logs for `⚠️  webhook event` or `❌ webhook-processor tick failed` for the next 10 minutes.
+- [ ] Sanity-check `pending_webhook_events`:
+  ```sql
+  SELECT id, event_type, status, attempts, next_retry_at, last_error
+  FROM pending_webhook_events
+  WHERE created_at > now() - interval '10 minutes'
+  ORDER BY created_at DESC;
+  ```
+  Expected: new rows (if any) reach `status = 'done'` within their retry window. `status = 'failed'` is a page-worthy alert.
+
+## Incident response
+
+### "A client says their deploy email never arrived"
+
+1. Find the event by website:
+   ```sql
+   SELECT e.id, e.status, e.attempts, e.last_error, e.created_at, e.processed_at
+   FROM pending_webhook_events e
+   WHERE e.event_type = 'deployment'
+     AND e.payload->>'website_id' = '<website-uuid>'
+     AND e.created_at > now() - interval '48 hours'
+   ORDER BY e.created_at DESC;
+   ```
+2. If `status = 'failed'`: read `last_error`, fix the underlying cause, then manually re-queue if appropriate (`UPDATE ... SET status = 'pending', attempts = 0, next_retry_at = now()`).
+3. If `status = 'pending'` with high `attempts`: the processor is still trying. Watch logs for the next tick.
+4. If no row exists: the request was dropped **before** it reached our DB. That's the residual restart-window risk. Ask the client's CI to re-trigger the deploy (or reconstruct the summary manually and POST it ourselves). This is the case DEV-701 could not fully eliminate — document it and add the client's deploy window to the table above so we can avoid it next time.
+
+### "Lots of `failed` events piling up"
+
+That means retries are exhausting for a real reason (website deleted, DB schema drift, email service outage). Check `last_error`, fix the root cause, then re-queue the affected rows by setting `status = 'pending'` and `next_retry_at = now()`.
+
+## Related code
+
+- `src/lib/webhook-processor.ts` — poller + per-event processor
+- `src/services/pending-webhook-events.ts` — queue service layer
+- `src/controllers/deployments.ts` — insert-first request handler
+- `supabase/migrations/20260414_create_pending_webhook_events.sql` — schema

--- a/docs/runbooks/deploy-window.md
+++ b/docs/runbooks/deploy-window.md
@@ -85,3 +85,23 @@ That means retries are exhausting for a real reason (website deleted, DB schema 
 - `src/services/pending-webhook-events.ts` — queue service layer
 - `src/controllers/deployments.ts` — insert-first request handler
 - `supabase/migrations/20260414_create_pending_webhook_events.sql` — schema
+
+## Multi-instance safety
+
+The webhook processor runs **in-process** inside the Express server. If we ever scale the DO App Platform component past one instance, every instance will poll the same queue rows and race — resulting in duplicate deployment records and duplicate emails.
+
+**Until this is hardened (e.g. moved to pg_cron / Supabase Edge Functions, or using `FOR UPDATE SKIP LOCKED` via an RPC), only ONE instance should run the processor.**
+
+Gate via the `WEBHOOK_PROCESSOR_ENABLED` env var. Default is `true` (processor runs). For multi-instance deploys, set `WEBHOOK_PROCESSOR_ENABLED=false` on all but one instance.
+
+## Idempotency
+
+`processDeploymentEvent` reads `result_ref` from the queue row at the start of each attempt. If a previous attempt already created a `website_deployments` row but crashed before `markDone`, the retry uses the existing deployment id (no duplicate row, no duplicate email).
+
+## Data retention
+
+`cleanupOldEvents` runs every 24 hours and deletes:
+- `status='done'` rows older than 30 days
+- `status='failed'` rows older than 90 days
+
+If you need to audit an incident older than those windows, grab the rows before they're purged (or disable the cleanup interval temporarily via code).

--- a/src/controllers/deployments.ts
+++ b/src/controllers/deployments.ts
@@ -5,13 +5,20 @@ import { db, Tables } from '../lib/db'
 import { handleGenericError } from '../utils/http'
 import deploymentsService from '../services/deployments'
 import pendingWebhookEvents from '../services/pending-webhook-events'
-import { processEvent } from '../lib/webhook-processor'
+import {
+    processEvent,
+    INLINE_OWNERSHIP_BUFFER_MS,
+} from '../lib/webhook-processor'
 
 // DEV-701: Deploy-window resilience.
 // This endpoint is hit by client CI/CD with data that is generated once and
-// never re-sent. Persist the payload to `pending_webhook_events` first, then
-// attempt the real work (create deployment row + send email). If the inline
-// attempt fails, the row is already safe — the background poller will retry.
+// never re-sent. Flow:
+//   1. Pre-validate website_id so invalid UUIDs don't pollute the queue.
+//   2. Persist payload to pending_webhook_events (next_retry_at is pushed
+//      past the inline attempt so the poller can't claim this row mid-work).
+//   3. Attempt the real work inline. On success → 201 with the deployment.
+//      On transient failure → 202; the poller will retry.
+//      On permanent failure → delete the row and return the error.
 const create = async (req: Request, res: Response): Promise<Response> => {
     try {
         const errors = validationResult(req)
@@ -22,31 +29,46 @@ const create = async (req: Request, res: Response): Promise<Response> => {
         const { website_id, changed_urls, deploy_summary, internal_notes } =
             req.body
 
+        const { data: website, error: websiteError } = await db
+            .from(Tables.WEBSITES)
+            .select('id')
+            .eq('id', website_id)
+            .single()
+
+        if (websiteError || !website) {
+            return res.status(404).json({ error: 'Website not found' })
+        }
+
         const pendingEvent = await pendingWebhookEvents.insertPending(
             'deployment',
             { website_id, changed_urls, deploy_summary, internal_notes },
+            INLINE_OWNERSHIP_BUFFER_MS,
         )
 
-        const succeeded = await processEvent(pendingEvent)
+        const result = await processEvent(pendingEvent)
 
-        if (succeeded) {
-            const resultRef = await getResultRef(pendingEvent.id)
-            const deployment = resultRef
-                ? await deploymentsService.getDeploymentById(resultRef)
-                : null
+        if (result.status === 'success') {
+            const deployment = await deploymentsService.getDeploymentById(
+                result.deploymentId,
+            )
+            return res.status(201).json(deployment)
+        }
 
-            if (deployment) {
-                return res.status(201).json(deployment)
-            }
-            return res.status(201).json({
-                queued: false,
-                event_id: pendingEvent.id,
+        if (result.status === 'permanent_failure') {
+            // Rare: website existed at step 1 but disappeared before
+            // processEvent re-validated, or an unknown event_type slipped
+            // through. Delete the row so garbage doesn't accumulate.
+            await pendingWebhookEvents.deleteEvent(pendingEvent.id)
+            return res.status(400).json({
+                error: 'Deployment could not be processed',
+                reason: result.reason,
             })
         }
 
-        // Inline attempt failed. The event row is safe and will be retried by
-        // the background poller. Respond 202 so the client's CI/CD pipeline
-        // treats this as a successful hand-off.
+        // result.status === 'retry_scheduled'
+        // The row is durable; the background poller will retry on its
+        // schedule. Return 202 so the client's CI treats this as an
+        // accepted hand-off.
         return res.status(202).json({
             queued: true,
             event_id: pendingEvent.id,
@@ -54,17 +76,6 @@ const create = async (req: Request, res: Response): Promise<Response> => {
     } catch (err) {
         return handleGenericError(err, res)
     }
-}
-
-const getResultRef = async (eventId: string): Promise<string | null> => {
-    const { data, error } = await db
-        .from(Tables.PENDING_WEBHOOK_EVENTS)
-        .select('result_ref')
-        .eq('id', eventId)
-        .single()
-
-    if (error || !data) return null
-    return (data as { result_ref: string | null }).result_ref
 }
 
 const getByWebsite = async (req: Request, res: Response): Promise<Response> => {

--- a/src/controllers/deployments.ts
+++ b/src/controllers/deployments.ts
@@ -8,17 +8,19 @@ import pendingWebhookEvents from '../services/pending-webhook-events'
 import {
     processEvent,
     INLINE_OWNERSHIP_BUFFER_MS,
+    WebsiteContext,
 } from '../lib/webhook-processor'
 
 // DEV-701: Deploy-window resilience.
 // This endpoint is hit by client CI/CD with data that is generated once and
 // never re-sent. Flow:
-//   1. Pre-validate website_id so invalid UUIDs don't pollute the queue.
+//   1. Pre-validate website_id (fetches full row so processEvent can skip
+//      the re-SELECT on the inline path).
 //   2. Persist payload to pending_webhook_events (next_retry_at is pushed
 //      past the inline attempt so the poller can't claim this row mid-work).
 //   3. Attempt the real work inline. On success → 201 with the deployment.
 //      On transient failure → 202; the poller will retry.
-//      On permanent failure → delete the row and return the error.
+//      On permanent failure → markFailed stands as audit trail.
 const create = async (req: Request, res: Response): Promise<Response> => {
     try {
         const errors = validationResult(req)
@@ -31,7 +33,7 @@ const create = async (req: Request, res: Response): Promise<Response> => {
 
         const { data: website, error: websiteError } = await db
             .from(Tables.WEBSITES)
-            .select('id')
+            .select('id, title, contact_email, client_id')
             .eq('id', website_id)
             .single()
 
@@ -45,20 +47,20 @@ const create = async (req: Request, res: Response): Promise<Response> => {
             INLINE_OWNERSHIP_BUFFER_MS,
         )
 
-        const result = await processEvent(pendingEvent)
+        const result = await processEvent(
+            pendingEvent,
+            website as WebsiteContext,
+        )
 
         if (result.status === 'success') {
-            const deployment = await deploymentsService.getDeploymentById(
-                result.deploymentId,
-            )
-            return res.status(201).json(deployment)
+            return res.status(201).json(result.deployment)
         }
 
         if (result.status === 'permanent_failure') {
             // Rare: website existed at step 1 but disappeared before
             // processEvent re-validated, or an unknown event_type slipped
-            // through. Delete the row so garbage doesn't accumulate.
-            await pendingWebhookEvents.deleteEvent(pendingEvent.id)
+            // through. The row is kept as status='failed' for audit; the
+            // 24h cleanup will remove it after 90 days.
             return res.status(400).json({
                 error: 'Deployment could not be processed',
                 reason: result.reason,

--- a/src/controllers/deployments.ts
+++ b/src/controllers/deployments.ts
@@ -4,8 +4,14 @@ import { validationResult } from 'express-validator'
 import { db, Tables } from '../lib/db'
 import { handleGenericError } from '../utils/http'
 import deploymentsService from '../services/deployments'
-import { sendDeploymentEmail } from '../lib/nylas-mailer'
+import pendingWebhookEvents from '../services/pending-webhook-events'
+import { processEvent } from '../lib/webhook-processor'
 
+// DEV-701: Deploy-window resilience.
+// This endpoint is hit by client CI/CD with data that is generated once and
+// never re-sent. Persist the payload to `pending_webhook_events` first, then
+// attempt the real work (create deployment row + send email). If the inline
+// attempt fails, the row is already safe — the background poller will retry.
 const create = async (req: Request, res: Response): Promise<Response> => {
     try {
         const errors = validationResult(req)
@@ -16,53 +22,49 @@ const create = async (req: Request, res: Response): Promise<Response> => {
         const { website_id, changed_urls, deploy_summary, internal_notes } =
             req.body
 
-        // 1. Verify website exists
-        const { data: website, error: websiteError } = await db
-            .from(Tables.WEBSITES)
-            .select('id, title, contact_email, client_id')
-            .eq('id', website_id)
-            .single()
+        const pendingEvent = await pendingWebhookEvents.insertPending(
+            'deployment',
+            { website_id, changed_urls, deploy_summary, internal_notes },
+        )
 
-        if (websiteError || !website) {
-            return res.status(404).json({ error: 'Website not found' })
-        }
+        const succeeded = await processEvent(pendingEvent)
 
-        // 2. Create deployment record
-        const deployment = await deploymentsService.createDeployment({
-            website_id,
-            changed_urls,
-            deploy_summary,
-            internal_notes
-        })
+        if (succeeded) {
+            const resultRef = await getResultRef(pendingEvent.id)
+            const deployment = resultRef
+                ? await deploymentsService.getDeploymentById(resultRef)
+                : null
 
-        // 3. Send email notification (if contact email exists)
-        if (website.contact_email) {
-            try {
-                await sendDeploymentEmail({
-                    to: website.contact_email,
-                    websiteTitle: website.title,
-                    deploymentDate: new Date(
-                        deployment.created_at
-                    ).toLocaleDateString(),
-                    summaryMarkdown: deploy_summary
-                })
-                console.log(
-                    '✅ Deployment email sent:',
-                    website.contact_email,
-                    'for',
-                    website.title
-                )
-            } catch (emailError) {
-                console.error('❌ Error sending deployment email:', emailError)
-                // Don't fail the request if email fails
+            if (deployment) {
+                return res.status(201).json(deployment)
             }
+            return res.status(201).json({
+                queued: false,
+                event_id: pendingEvent.id,
+            })
         }
 
-        // 4. Return deployment record
-        return res.status(201).json(deployment)
+        // Inline attempt failed. The event row is safe and will be retried by
+        // the background poller. Respond 202 so the client's CI/CD pipeline
+        // treats this as a successful hand-off.
+        return res.status(202).json({
+            queued: true,
+            event_id: pendingEvent.id,
+        })
     } catch (err) {
         return handleGenericError(err, res)
     }
+}
+
+const getResultRef = async (eventId: string): Promise<string | null> => {
+    const { data, error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .select('result_ref')
+        .eq('id', eventId)
+        .single()
+
+    if (error || !data) return null
+    return (data as { result_ref: string | null }).result_ref
 }
 
 const getByWebsite = async (req: Request, res: Response): Promise<Response> => {

--- a/src/controllers/deployments.ts
+++ b/src/controllers/deployments.ts
@@ -10,6 +10,7 @@ import {
     INLINE_OWNERSHIP_BUFFER_MS,
     WebsiteContext,
 } from '../lib/webhook-processor'
+import { assertNever } from '../utils/assert'
 
 // DEV-701: Deploy-window resilience.
 // This endpoint is hit by client CI/CD with data that is generated once and
@@ -52,29 +53,37 @@ const create = async (req: Request, res: Response): Promise<Response> => {
             website as WebsiteContext,
         )
 
-        if (result.status === 'success') {
-            return res.status(201).json(result.deployment)
+        switch (result.status) {
+            case 'success':
+                if (result.warning) {
+                    // Deployment row was created but the notification email
+                    // failed. The queue row is marked status='done' with
+                    // last_error set so ops can query for degraded events.
+                    console.warn(
+                        `⚠️  deployment ${result.deployment.id} created but email failed (${result.warning})`,
+                    )
+                }
+                return res.status(201).json(result.deployment)
+            case 'permanent_failure':
+                // Rare: website existed at step 1 but disappeared before
+                // processEvent re-validated, or an unknown event_type
+                // slipped through. Row is kept as status='failed' for
+                // audit; the 24h cleanup removes it after 90 days.
+                return res.status(400).json({
+                    error: 'Deployment could not be processed',
+                    reason: result.reason,
+                })
+            case 'retry_scheduled':
+                // The row is durable; the background poller will retry on
+                // its schedule. Return 202 so the client's CI treats this
+                // as an accepted hand-off.
+                return res.status(202).json({
+                    queued: true,
+                    event_id: pendingEvent.id,
+                })
+            default:
+                return assertNever(result)
         }
-
-        if (result.status === 'permanent_failure') {
-            // Rare: website existed at step 1 but disappeared before
-            // processEvent re-validated, or an unknown event_type slipped
-            // through. The row is kept as status='failed' for audit; the
-            // 24h cleanup will remove it after 90 days.
-            return res.status(400).json({
-                error: 'Deployment could not be processed',
-                reason: result.reason,
-            })
-        }
-
-        // result.status === 'retry_scheduled'
-        // The row is durable; the background poller will retry on its
-        // schedule. Return 202 so the client's CI treats this as an
-        // accepted hand-off.
-        return res.status(202).json({
-            queued: true,
-            event_id: pendingEvent.id,
-        })
     } catch (err) {
         return handleGenericError(err, res)
     }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -34,6 +34,7 @@ export const Tables = {
     CMS_TEMPLATES: 'cms_templates',
     CMS_PAGES: 'cms_pages',
     WEBSITE_DOMAINS: 'website_domains',
+    PENDING_WEBHOOK_EVENTS: 'pending_webhook_events',
 }
 
 // Valid project status values for websites and apps

--- a/src/lib/webhook-processor.ts
+++ b/src/lib/webhook-processor.ts
@@ -48,9 +48,22 @@ export class NonRetryableWebhookError extends Error {
     }
 }
 
+export interface WebsiteContext {
+    id: string
+    title: string
+    contact_email: string | null
+    client_id: string
+}
+
+export interface DeploymentRecord {
+    id: string
+    created_at: string
+    [key: string]: unknown
+}
+
 export interface SuccessResult {
     status: 'success'
-    deploymentId: string
+    deployment: DeploymentRecord
     attempts: number
 }
 export interface RetryScheduledResult {
@@ -70,83 +83,92 @@ export type ProcessResult =
     | PermanentFailureResult
 
 /**
- * Process a deployment event: verify the website, create the deployment row,
- * persist result_ref for idempotency, then send the notification email.
+ * Process a deployment event: optionally skip the website re-fetch when the
+ * caller already has it (the inline controller path), create/reuse the
+ * deployment row, persist result_ref + email_sent_at for idempotency, then
+ * send the notification email.
  *
- * Idempotency: if the event already has result_ref set (i.e. a prior attempt
- * created the deployment row but crashed before markDone), skip straight to
- * the email step using the existing deployment. This prevents duplicate
- * website_deployments rows if the Node process dies between createDeployment
- * and markDone.
+ * Idempotency:
+ * - result_ref set → reuse the existing deployment row; do not INSERT again.
+ * - email_sent_at set → skip the email send; do not notify the client again.
+ * Both flags persist before the next fallible step so a crash between any
+ * two steps cannot cause duplicate DB rows or duplicate emails.
  *
- * Email failures are swallowed — once the deployment row is persisted, the
- * client-facing data is safe. A missed email is annoying, not catastrophic.
+ * Returns the full deployment record so callers (the controller) can
+ * respond without another round-trip to Supabase.
  */
 export const processDeploymentEvent = async (
     event: PendingWebhookEvent,
-): Promise<string> => {
+    prefetchedWebsite?: WebsiteContext,
+): Promise<DeploymentRecord> => {
     const payload = event.payload as unknown as DeploymentEventPayload
     const { website_id, changed_urls, deploy_summary, internal_notes } = payload
 
-    const { data: website, error: websiteError } = await db
-        .from(Tables.WEBSITES)
-        .select('id, title, contact_email, client_id')
-        .eq('id', website_id)
-        .single()
+    let website: WebsiteContext
+    if (prefetchedWebsite && prefetchedWebsite.id === website_id) {
+        website = prefetchedWebsite
+    } else {
+        const { data, error: websiteError } = await db
+            .from(Tables.WEBSITES)
+            .select('id, title, contact_email, client_id')
+            .eq('id', website_id)
+            .single()
 
-    if (websiteError || !website) {
-        throw new NonRetryableWebhookError(
-            ErrorReasons.WEBSITE_NOT_FOUND,
-            `website_id=${website_id}`,
-        )
+        if (websiteError || !data) {
+            throw new NonRetryableWebhookError(
+                ErrorReasons.WEBSITE_NOT_FOUND,
+                `website_id=${website_id}`,
+            )
+        }
+        website = data as WebsiteContext
     }
 
-    let deploymentId: string
-    let deploymentCreatedAt: string
+    let deployment: DeploymentRecord
 
     if (event.result_ref) {
         const existing = await deploymentsService.getDeploymentById(
             event.result_ref,
         )
         if (existing) {
-            deploymentId = existing.id
-            deploymentCreatedAt = existing.created_at
+            deployment = existing as unknown as DeploymentRecord
         } else {
+            console.warn(
+                `⚠️  event ${event.id}: result_ref ${event.result_ref} missing; recreating deployment`,
+            )
             const fresh = await deploymentsService.createDeployment({
                 website_id,
                 changed_urls,
                 deploy_summary,
                 internal_notes,
             })
-            deploymentId = fresh.id
-            deploymentCreatedAt = fresh.created_at
-            await pendingWebhookEvents.setResultRef(event.id, deploymentId)
+            deployment = fresh as DeploymentRecord
+            await pendingWebhookEvents.setResultRef(event.id, deployment.id)
         }
     } else {
-        const deployment = await deploymentsService.createDeployment({
+        const fresh = await deploymentsService.createDeployment({
             website_id,
             changed_urls,
             deploy_summary,
             internal_notes,
         })
-        deploymentId = deployment.id
-        deploymentCreatedAt = deployment.created_at
+        deployment = fresh as DeploymentRecord
         // Persist result_ref BEFORE attempting email so a crash between
         // createDeployment and markDone cannot cause duplicate rows on
         // the next retry.
-        await pendingWebhookEvents.setResultRef(event.id, deploymentId)
+        await pendingWebhookEvents.setResultRef(event.id, deployment.id)
     }
 
-    if (website.contact_email) {
+    if (!event.email_sent_at && website.contact_email) {
         try {
             await sendDeploymentEmail({
                 to: website.contact_email,
                 websiteTitle: website.title,
                 deploymentDate: new Date(
-                    deploymentCreatedAt,
+                    deployment.created_at,
                 ).toLocaleDateString(),
                 summaryMarkdown: deploy_summary,
             })
+            await pendingWebhookEvents.setEmailSent(event.id)
             console.log(
                 '✅ Deployment email sent:',
                 website.contact_email,
@@ -161,13 +183,16 @@ export const processDeploymentEvent = async (
         }
     }
 
-    return deploymentId
+    return deployment
 }
 
-const runProcessor = async (event: PendingWebhookEvent): Promise<string> => {
+const runProcessor = async (
+    event: PendingWebhookEvent,
+    prefetchedWebsite?: WebsiteContext,
+): Promise<DeploymentRecord> => {
     switch (event.event_type as WebhookEventType) {
         case 'deployment':
-            return processDeploymentEvent(event)
+            return processDeploymentEvent(event, prefetchedWebsite)
         default:
             throw new NonRetryableWebhookError(
                 ErrorReasons.UNKNOWN,
@@ -179,9 +204,14 @@ const runProcessor = async (event: PendingWebhookEvent): Promise<string> => {
 const classifyError = (err: unknown): ErrorReason => {
     if (err instanceof NonRetryableWebhookError) return err.reason
     const msg = err instanceof Error ? err.message : String(err)
-    if (/email|nylas|smtp/i.test(msg)) return ErrorReasons.EMAIL_SEND_FAILED
-    if (/insert|duplicate|constraint|relation/i.test(msg)) {
+    // Order matters: DB-shape errors often mention 'email' as a column
+    // name in leads/contact-forms tables, so check DB-failure patterns
+    // first to avoid mis-classifying them as EMAIL_SEND_FAILED.
+    if (/\b(insert|duplicate|constraint|relation|column|pgrst)\b/i.test(msg)) {
         return ErrorReasons.DB_INSERT_FAILED
+    }
+    if (/\b(nylas|smtp|sendgrid|mailer|failed to send)\b/i.test(msg)) {
+        return ErrorReasons.EMAIL_SEND_FAILED
     }
     return ErrorReasons.UNKNOWN
 }
@@ -195,12 +225,13 @@ const classifyError = (err: unknown): ErrorReason => {
  */
 export const processEvent = async (
     event: PendingWebhookEvent,
+    prefetchedWebsite?: WebsiteContext,
 ): Promise<ProcessResult> => {
     const attempts = event.attempts + 1
     try {
-        const deploymentId = await runProcessor(event)
-        await pendingWebhookEvents.markDone(event.id, attempts, deploymentId)
-        return { status: 'success', deploymentId, attempts }
+        const deployment = await runProcessor(event, prefetchedWebsite)
+        await pendingWebhookEvents.markDone(event.id, attempts, deployment.id)
+        return { status: 'success', deployment, attempts }
     } catch (err) {
         const isNonRetryable = err instanceof NonRetryableWebhookError
         const reason = classifyError(err)

--- a/src/lib/webhook-processor.ts
+++ b/src/lib/webhook-processor.ts
@@ -4,7 +4,9 @@ import pendingWebhookEvents, {
     ErrorReasons,
     PendingWebhookEvent,
 } from '../services/pending-webhook-events'
-import deploymentsService from '../services/deployments'
+import deploymentsService, {
+    DeploymentRecord as DeploymentRow,
+} from '../services/deployments'
 import { sendDeploymentEmail } from './nylas-mailer'
 
 // How often the in-process poller wakes up to check for due retries.
@@ -23,7 +25,7 @@ const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000
 
 export type WebhookEventType = 'deployment'
 
-export interface DeploymentEventPayload {
+export interface DeploymentEventPayload extends Record<string, unknown> {
     website_id: string
     changed_urls: string[]
     deploy_summary: string
@@ -38,8 +40,8 @@ export interface DeploymentEventPayload {
  * to console for operators but never persisted.
  */
 export class NonRetryableWebhookError extends Error {
-    reason: ErrorReason
-    detail?: string
+    readonly reason: ErrorReason
+    readonly detail?: string
     constructor(reason: ErrorReason, detail?: string) {
         super(`non-retryable: ${reason}`)
         this.name = 'NonRetryableWebhookError'
@@ -55,16 +57,22 @@ export interface WebsiteContext {
     client_id: string
 }
 
-export interface DeploymentRecord {
-    id: string
-    created_at: string
-    [key: string]: unknown
+// Re-export the real row shape from the deployments service so consumers
+// get the full typed shape (changed_urls, indexing_status, etc.) instead
+// of the opaque `[key: string]: unknown` placeholder this module used to
+// define locally.
+export type DeploymentRecord = DeploymentRow
+
+interface ProcessorOutcome {
+    deployment: DeploymentRecord
+    warning?: ErrorReason
 }
 
 export interface SuccessResult {
     status: 'success'
     deployment: DeploymentRecord
     attempts: number
+    warning?: ErrorReason
 }
 export interface RetryScheduledResult {
     status: 'retry_scheduled'
@@ -91,18 +99,24 @@ export type ProcessResult =
  * Idempotency:
  * - result_ref set → reuse the existing deployment row; do not INSERT again.
  * - email_sent_at set → skip the email send; do not notify the client again.
- * Both flags persist before the next fallible step so a crash between any
- * two steps cannot cause duplicate DB rows or duplicate emails.
+ * Both flags persist (with local retries) before the next fallible step so
+ * a crash or transient bookkeeping failure between steps cannot cause
+ * duplicate DB rows or duplicate emails.
+ *
+ * Email failure is captured as a `warning` on the return value (rather than
+ * thrown) because the client-facing deployment data is already safe; email
+ * is a best-effort notification. The warning propagates to markDone's
+ * last_error so ops can query for "done but degraded" events.
  *
  * Returns the full deployment record so callers (the controller) can
  * respond without another round-trip to Supabase.
  */
 export const processDeploymentEvent = async (
-    event: PendingWebhookEvent,
+    event: PendingWebhookEvent<DeploymentEventPayload>,
     prefetchedWebsite?: WebsiteContext,
-): Promise<DeploymentRecord> => {
-    const payload = event.payload as unknown as DeploymentEventPayload
-    const { website_id, changed_urls, deploy_summary, internal_notes } = payload
+): Promise<ProcessorOutcome> => {
+    const { website_id, changed_urls, deploy_summary, internal_notes } =
+        event.payload
 
     let website: WebsiteContext
     if (prefetchedWebsite && prefetchedWebsite.id === website_id) {
@@ -126,23 +140,41 @@ export const processDeploymentEvent = async (
     let deployment: DeploymentRecord
 
     if (event.result_ref) {
-        const existing = await deploymentsService.getDeploymentById(
-            event.result_ref,
-        )
-        if (existing) {
-            deployment = existing as unknown as DeploymentRecord
-        } else {
-            console.warn(
-                `⚠️  event ${event.id}: result_ref ${event.result_ref} missing; recreating deployment`,
+        try {
+            const existing = await deploymentsService.getDeploymentById(
+                event.result_ref,
             )
-            const fresh = await deploymentsService.createDeployment({
-                website_id,
-                changed_urls,
-                deploy_summary,
-                internal_notes,
-            })
-            deployment = fresh as DeploymentRecord
-            await pendingWebhookEvents.setResultRef(event.id, deployment.id)
+            if (existing) {
+                deployment = existing as unknown as DeploymentRecord
+            } else {
+                console.warn(
+                    `⚠️  event ${event.id}: result_ref ${event.result_ref} missing; recreating deployment`,
+                )
+                const fresh = await deploymentsService.createDeployment({
+                    website_id,
+                    changed_urls,
+                    deploy_summary,
+                    internal_notes,
+                })
+                deployment = fresh as DeploymentRecord
+                await pendingWebhookEvents.setResultRef(
+                    event.id,
+                    deployment.id,
+                )
+            }
+        } catch (err) {
+            // If the idempotency lookup itself fails transiently (Supabase
+            // flap), bubbling would burn retries after already-successful
+            // work. Reconstruct a minimal deployment record from known
+            // state; downstream only needs id + created_at.
+            console.warn(
+                `⚠️  event ${event.id}: idempotent fetch failed; reusing ref without refetch:`,
+                err,
+            )
+            deployment = {
+                id: event.result_ref,
+                created_at: event.created_at,
+            } as DeploymentRecord
         }
     } else {
         const fresh = await deploymentsService.createDeployment({
@@ -154,9 +186,12 @@ export const processDeploymentEvent = async (
         deployment = fresh as DeploymentRecord
         // Persist result_ref BEFORE attempting email so a crash between
         // createDeployment and markDone cannot cause duplicate rows on
-        // the next retry.
+        // the next retry. setResultRef internally retries transient
+        // failures to avoid orphaning the deployment row.
         await pendingWebhookEvents.setResultRef(event.id, deployment.id)
     }
+
+    let warning: ErrorReason | undefined
 
     if (!event.email_sent_at && website.contact_email) {
         try {
@@ -177,22 +212,26 @@ export const processDeploymentEvent = async (
             )
         } catch (emailError) {
             console.error(
-                '❌ Error sending deployment email (non-fatal):',
+                '❌ Error sending deployment email (non-fatal; event marked done with warning):',
                 emailError,
             )
+            warning = ErrorReasons.EMAIL_SEND_FAILED
         }
     }
 
-    return deployment
+    return { deployment, warning }
 }
 
 const runProcessor = async (
     event: PendingWebhookEvent,
     prefetchedWebsite?: WebsiteContext,
-): Promise<DeploymentRecord> => {
+): Promise<ProcessorOutcome> => {
     switch (event.event_type as WebhookEventType) {
         case 'deployment':
-            return processDeploymentEvent(event, prefetchedWebsite)
+            return processDeploymentEvent(
+                event as PendingWebhookEvent<DeploymentEventPayload>,
+                prefetchedWebsite,
+            )
         default:
             throw new NonRetryableWebhookError(
                 ErrorReasons.UNKNOWN,
@@ -222,47 +261,110 @@ const classifyError = (err: unknown): ErrorReason => {
  *
  * Returns a discriminated result so callers can distinguish success from
  * scheduled-retry from permanent-failure without additional round-trips.
+ *
+ * markDone/scheduleNextRetry failures that happen AFTER successful user-
+ * facing work do not propagate — the event row stays pending and the next
+ * retry is idempotent (result_ref + email_sent_at short-circuit the work).
  */
 export const processEvent = async (
     event: PendingWebhookEvent,
     prefetchedWebsite?: WebsiteContext,
 ): Promise<ProcessResult> => {
     const attempts = event.attempts + 1
+    let outcome: ProcessorOutcome
     try {
-        const deployment = await runProcessor(event, prefetchedWebsite)
-        await pendingWebhookEvents.markDone(event.id, attempts, deployment.id)
-        return { status: 'success', deployment, attempts }
+        outcome = await runProcessor(event, prefetchedWebsite)
     } catch (err) {
-        const isNonRetryable = err instanceof NonRetryableWebhookError
-        const reason = classifyError(err)
-        const rawMessage = err instanceof Error ? err.message : String(err)
+        return handleProcessorFailure(event, attempts, err)
+    }
 
-        if (isNonRetryable) {
-            console.error(
-                `❌ webhook event ${event.id} non-retryable (${reason}):`,
-                (err as NonRetryableWebhookError).detail ?? rawMessage,
-            )
-            await pendingWebhookEvents.markFailed(event.id, attempts, reason)
-            return { status: 'permanent_failure', attempts, reason }
-        }
-
-        console.error(
-            `⚠️  webhook event ${event.id} attempt ${attempts} failed (${reason}):`,
-            rawMessage,
+    try {
+        await pendingWebhookEvents.markDone(
+            event.id,
+            attempts,
+            outcome.deployment.id,
+            outcome.warning,
         )
+    } catch (markErr) {
+        // The user-facing work succeeded (deployment row exists, email
+        // sent or warning logged). Bookkeeping failed, but the pending
+        // row still has result_ref + email_sent_at set — the next poller
+        // tick will idempotently reach markDone. Report success anyway
+        // so the inline caller doesn't 500 after real success.
+        console.error(
+            `⚠️  webhook event ${event.id} markDone failed (will self-heal on next tick):`,
+            markErr,
+        )
+    }
 
+    return {
+        status: 'success',
+        deployment: outcome.deployment,
+        attempts,
+        warning: outcome.warning,
+    }
+}
+
+const handleProcessorFailure = async (
+    event: PendingWebhookEvent,
+    attempts: number,
+    err: unknown,
+): Promise<ProcessResult> => {
+    const isNonRetryable = err instanceof NonRetryableWebhookError
+    const reason = classifyError(err)
+    const rawMessage = err instanceof Error ? err.message : String(err)
+
+    if (isNonRetryable) {
+        console.error(
+            `❌ webhook event ${event.id} non-retryable (${reason}):`,
+            (err as NonRetryableWebhookError).detail ?? rawMessage,
+        )
+        try {
+            await pendingWebhookEvents.markFailed(event.id, attempts, reason)
+        } catch (markErr) {
+            console.error(
+                `⚠️  markFailed failed for event ${event.id}; poller will retry bookkeeping:`,
+                markErr,
+            )
+        }
+        return { status: 'permanent_failure', attempts, reason }
+    }
+
+    console.error(
+        `⚠️  webhook event ${event.id} attempt ${attempts} failed (${reason}):`,
+        rawMessage,
+    )
+
+    try {
         const { scheduled } = await pendingWebhookEvents.scheduleNextRetry(
             event.id,
             attempts,
             reason,
         )
-        if (!scheduled) {
-            console.error(
-                `❌ webhook event ${event.id} retry budget exhausted (${reason})`,
-            )
-            await pendingWebhookEvents.markFailed(event.id, attempts, reason)
-            return { status: 'permanent_failure', attempts, reason }
+        if (scheduled) {
+            return { status: 'retry_scheduled', attempts, reason }
         }
+        console.error(
+            `❌ webhook event ${event.id} retry budget exhausted (${reason})`,
+        )
+        try {
+            await pendingWebhookEvents.markFailed(event.id, attempts, reason)
+        } catch (markErr) {
+            console.error(
+                `⚠️  markFailed failed for event ${event.id}; poller will retry bookkeeping:`,
+                markErr,
+            )
+        }
+        return { status: 'permanent_failure', attempts, reason }
+    } catch (bookErr) {
+        // Bookkeeping write itself failed. The pending row still has
+        // next_retry_at in the past, so the poller will pick it up again
+        // and retry. Surface as retry_scheduled so the inline caller
+        // returns 202 (accepted) rather than 500.
+        console.error(
+            `⚠️  scheduleNextRetry failed for event ${event.id}; poller will catch it:`,
+            bookErr,
+        )
         return { status: 'retry_scheduled', attempts, reason }
     }
 }
@@ -303,7 +405,9 @@ const tick = async () => {
         console.log(
             `🔁 webhook-processor: processing ${due.length} due event(s)`,
         )
-        await runWithConcurrency(due, INLINE_CONCURRENCY, processEvent)
+        await runWithConcurrency(due, INLINE_CONCURRENCY, event =>
+            processEvent(event),
+        )
     } catch (err) {
         console.error('❌ webhook-processor tick failed:', err)
     } finally {

--- a/src/lib/webhook-processor.ts
+++ b/src/lib/webhook-processor.ts
@@ -1,16 +1,25 @@
 import { db, Tables } from './db'
 import pendingWebhookEvents, {
+    ErrorReason,
+    ErrorReasons,
     PendingWebhookEvent,
 } from '../services/pending-webhook-events'
 import deploymentsService from '../services/deployments'
 import { sendDeploymentEmail } from './nylas-mailer'
 
 // How often the in-process poller wakes up to check for due retries.
-// The first attempt for any event happens inline in the request handler,
-// so this interval only affects retry latency after a failure.
-const POLL_INTERVAL_MS = 60_000
+// The first attempt for any event happens inline in the request handler;
+// this interval only affects retry latency after a failure.
+export const POLL_INTERVAL_MS = 60_000
+
+// Buffer added to a new row's next_retry_at at insert time so the poller
+// cannot claim a row while the inline handler is still processing it.
+// Set comfortably above any realistic inline-handler duration.
+export const INLINE_OWNERSHIP_BUFFER_MS = 2 * POLL_INTERVAL_MS
 
 const BATCH_SIZE = 10
+const INLINE_CONCURRENCY = 3
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000
 
 export type WebhookEventType = 'deployment'
 
@@ -21,27 +30,62 @@ export interface DeploymentEventPayload {
     internal_notes?: string
 }
 
-// Thrown by processors when the error is permanent and no retry should be
-// attempted (e.g. the referenced website no longer exists). Causes the event
-// to be marked 'failed' immediately rather than scheduled for retry.
+/**
+ * Thrown by processors when the error is permanent and no retry should be
+ * attempted (e.g. the referenced website no longer exists). Causes the
+ * event to be marked 'failed' immediately rather than scheduled for retry.
+ * The `reason` is stored in last_error; the optional `detail` is logged
+ * to console for operators but never persisted.
+ */
 export class NonRetryableWebhookError extends Error {
-    constructor(message: string) {
-        super(message)
+    reason: ErrorReason
+    detail?: string
+    constructor(reason: ErrorReason, detail?: string) {
+        super(`non-retryable: ${reason}`)
         this.name = 'NonRetryableWebhookError'
+        this.reason = reason
+        this.detail = detail
     }
 }
 
+export interface SuccessResult {
+    status: 'success'
+    deploymentId: string
+    attempts: number
+}
+export interface RetryScheduledResult {
+    status: 'retry_scheduled'
+    attempts: number
+    reason: ErrorReason
+}
+export interface PermanentFailureResult {
+    status: 'permanent_failure'
+    attempts: number
+    reason: ErrorReason
+}
+
+export type ProcessResult =
+    | SuccessResult
+    | RetryScheduledResult
+    | PermanentFailureResult
+
 /**
  * Process a deployment event: verify the website, create the deployment row,
- * send the notification email. Returns the new deployment id on success.
+ * persist result_ref for idempotency, then send the notification email.
  *
- * Email failures are swallowed (same behavior as the pre-DEV-701 controller)
- * because the deployment record itself is the thing we cannot recover — once
- * it's in the DB, the client-facing data is safe even if the email bounces.
+ * Idempotency: if the event already has result_ref set (i.e. a prior attempt
+ * created the deployment row but crashed before markDone), skip straight to
+ * the email step using the existing deployment. This prevents duplicate
+ * website_deployments rows if the Node process dies between createDeployment
+ * and markDone.
+ *
+ * Email failures are swallowed — once the deployment row is persisted, the
+ * client-facing data is safe. A missed email is annoying, not catastrophic.
  */
 export const processDeploymentEvent = async (
-    payload: DeploymentEventPayload,
+    event: PendingWebhookEvent,
 ): Promise<string> => {
+    const payload = event.payload as unknown as DeploymentEventPayload
     const { website_id, changed_urls, deploy_summary, internal_notes } = payload
 
     const { data: website, error: websiteError } = await db
@@ -52,16 +96,46 @@ export const processDeploymentEvent = async (
 
     if (websiteError || !website) {
         throw new NonRetryableWebhookError(
-            `Website not found for deployment event: ${website_id}`,
+            ErrorReasons.WEBSITE_NOT_FOUND,
+            `website_id=${website_id}`,
         )
     }
 
-    const deployment = await deploymentsService.createDeployment({
-        website_id,
-        changed_urls,
-        deploy_summary,
-        internal_notes,
-    })
+    let deploymentId: string
+    let deploymentCreatedAt: string
+
+    if (event.result_ref) {
+        const existing = await deploymentsService.getDeploymentById(
+            event.result_ref,
+        )
+        if (existing) {
+            deploymentId = existing.id
+            deploymentCreatedAt = existing.created_at
+        } else {
+            const fresh = await deploymentsService.createDeployment({
+                website_id,
+                changed_urls,
+                deploy_summary,
+                internal_notes,
+            })
+            deploymentId = fresh.id
+            deploymentCreatedAt = fresh.created_at
+            await pendingWebhookEvents.setResultRef(event.id, deploymentId)
+        }
+    } else {
+        const deployment = await deploymentsService.createDeployment({
+            website_id,
+            changed_urls,
+            deploy_summary,
+            internal_notes,
+        })
+        deploymentId = deployment.id
+        deploymentCreatedAt = deployment.created_at
+        // Persist result_ref BEFORE attempting email so a crash between
+        // createDeployment and markDone cannot cause duplicate rows on
+        // the next retry.
+        await pendingWebhookEvents.setResultRef(event.id, deploymentId)
+    }
 
     if (website.contact_email) {
         try {
@@ -69,7 +143,7 @@ export const processDeploymentEvent = async (
                 to: website.contact_email,
                 websiteTitle: website.title,
                 deploymentDate: new Date(
-                    deployment.created_at,
+                    deploymentCreatedAt,
                 ).toLocaleDateString(),
                 summaryMarkdown: deploy_summary,
             })
@@ -87,70 +161,106 @@ export const processDeploymentEvent = async (
         }
     }
 
-    return deployment.id
+    return deploymentId
 }
 
-const runProcessor = async (
-    event: PendingWebhookEvent,
-): Promise<string | null> => {
+const runProcessor = async (event: PendingWebhookEvent): Promise<string> => {
     switch (event.event_type as WebhookEventType) {
         case 'deployment':
-            return processDeploymentEvent(
-                event.payload as unknown as DeploymentEventPayload,
-            )
+            return processDeploymentEvent(event)
         default:
             throw new NonRetryableWebhookError(
-                `Unknown event_type: ${event.event_type}`,
+                ErrorReasons.UNKNOWN,
+                `unknown event_type: ${event.event_type}`,
             )
     }
 }
 
+const classifyError = (err: unknown): ErrorReason => {
+    if (err instanceof NonRetryableWebhookError) return err.reason
+    const msg = err instanceof Error ? err.message : String(err)
+    if (/email|nylas|smtp/i.test(msg)) return ErrorReasons.EMAIL_SEND_FAILED
+    if (/insert|duplicate|constraint|relation/i.test(msg)) {
+        return ErrorReasons.DB_INSERT_FAILED
+    }
+    return ErrorReasons.UNKNOWN
+}
+
 /**
- * Process a single pending event. Used both by the inline path (first attempt
- * inside the request handler) and by the poller (scheduled retries).
+ * Process a single pending event. Used both by the inline path (first
+ * attempt inside the request handler) and by the poller (scheduled retries).
  *
- * Returns true on success, false on failure (the row is updated accordingly).
+ * Returns a discriminated result so callers can distinguish success from
+ * scheduled-retry from permanent-failure without additional round-trips.
  */
 export const processEvent = async (
     event: PendingWebhookEvent,
-): Promise<boolean> => {
+): Promise<ProcessResult> => {
     const attempts = event.attempts + 1
     try {
-        const resultRef = await runProcessor(event)
-        await pendingWebhookEvents.markDone(event.id, attempts, resultRef)
-        return true
+        const deploymentId = await runProcessor(event)
+        await pendingWebhookEvents.markDone(event.id, attempts, deploymentId)
+        return { status: 'success', deploymentId, attempts }
     } catch (err) {
         const isNonRetryable = err instanceof NonRetryableWebhookError
-        const message = err instanceof Error ? err.message : String(err)
+        const reason = classifyError(err)
+        const rawMessage = err instanceof Error ? err.message : String(err)
 
         if (isNonRetryable) {
             console.error(
-                `❌ webhook event ${event.id} failed permanently:`,
-                message,
+                `❌ webhook event ${event.id} non-retryable (${reason}):`,
+                (err as NonRetryableWebhookError).detail ?? rawMessage,
             )
-            await pendingWebhookEvents.scheduleNextRetry(
-                event.id,
-                Number.MAX_SAFE_INTEGER,
-                `[non-retryable] ${message}`,
-            )
-            return false
+            await pendingWebhookEvents.markFailed(event.id, attempts, reason)
+            return { status: 'permanent_failure', attempts, reason }
         }
 
         console.error(
-            `⚠️  webhook event ${event.id} attempt ${attempts} failed:`,
-            message,
+            `⚠️  webhook event ${event.id} attempt ${attempts} failed (${reason}):`,
+            rawMessage,
         )
-        await pendingWebhookEvents.scheduleNextRetry(
+
+        const { scheduled } = await pendingWebhookEvents.scheduleNextRetry(
             event.id,
             attempts,
-            message,
+            reason,
         )
-        return false
+        if (!scheduled) {
+            console.error(
+                `❌ webhook event ${event.id} retry budget exhausted (${reason})`,
+            )
+            await pendingWebhookEvents.markFailed(event.id, attempts, reason)
+            return { status: 'permanent_failure', attempts, reason }
+        }
+        return { status: 'retry_scheduled', attempts, reason }
     }
 }
 
 let processorInterval: NodeJS.Timeout | null = null
+let cleanupInterval: NodeJS.Timeout | null = null
 let processorRunning = false
+
+const runWithConcurrency = async <T>(
+    items: T[],
+    concurrency: number,
+    fn: (item: T) => Promise<unknown>,
+): Promise<void> => {
+    const queue = [...items]
+    const workers = Array.from({ length: Math.min(concurrency, queue.length) })
+    await Promise.all(
+        workers.map(async () => {
+            while (queue.length > 0) {
+                const item = queue.shift()
+                if (item === undefined) return
+                try {
+                    await fn(item)
+                } catch (err) {
+                    console.error('❌ processor worker error:', err)
+                }
+            }
+        }),
+    )
+}
 
 const tick = async () => {
     if (processorRunning) return
@@ -159,10 +269,10 @@ const tick = async () => {
         const due = await pendingWebhookEvents.fetchDue(BATCH_SIZE)
         if (due.length === 0) return
 
-        console.log(`🔁 webhook-processor: processing ${due.length} due event(s)`)
-        for (const event of due) {
-            await processEvent(event)
-        }
+        console.log(
+            `🔁 webhook-processor: processing ${due.length} due event(s)`,
+        )
+        await runWithConcurrency(due, INLINE_CONCURRENCY, processEvent)
     } catch (err) {
         console.error('❌ webhook-processor tick failed:', err)
     } finally {
@@ -170,14 +280,43 @@ const tick = async () => {
     }
 }
 
+const cleanupTick = async () => {
+    try {
+        const { done, failed } = await pendingWebhookEvents.cleanupOldEvents()
+        if (done + failed > 0) {
+            console.log(
+                `🧹 webhook-processor cleanup: removed ${done} done + ${failed} failed rows`,
+            )
+        }
+    } catch (err) {
+        console.error('❌ webhook-processor cleanup failed:', err)
+    }
+}
+
+/**
+ * Start the in-process poller. Gated behind WEBHOOK_PROCESSOR_ENABLED so
+ * that if we scale to multiple App Platform instances, only one runs the
+ * processor (avoids races on the same queue rows). Default: enabled.
+ */
 export const startWebhookProcessor = (): void => {
+    const flag = (process.env.WEBHOOK_PROCESSOR_ENABLED || 'true')
+        .trim()
+        .toLowerCase()
+    if (!['true', '1', 'on', 'yes'].includes(flag)) {
+        console.log(
+            '🚦 webhook-processor disabled via WEBHOOK_PROCESSOR_ENABLED',
+        )
+        return
+    }
     if (processorInterval) return
+
     processorInterval = setInterval(tick, POLL_INTERVAL_MS)
-    // Run one tick shortly after boot to pick up rows that were pending when
-    // the server last died, without waiting a full interval.
+    cleanupInterval = setInterval(cleanupTick, CLEANUP_INTERVAL_MS)
+    // Run one tick shortly after boot to pick up rows that were pending
+    // when the server last died, without waiting a full interval.
     setTimeout(tick, 5_000)
     console.log(
-        `🚀 webhook-processor started (interval ${POLL_INTERVAL_MS}ms, batch ${BATCH_SIZE})`,
+        `🚀 webhook-processor started (poll ${POLL_INTERVAL_MS}ms, batch ${BATCH_SIZE}, concurrency ${INLINE_CONCURRENCY})`,
     )
 }
 
@@ -185,5 +324,9 @@ export const stopWebhookProcessor = (): void => {
     if (processorInterval) {
         clearInterval(processorInterval)
         processorInterval = null
+    }
+    if (cleanupInterval) {
+        clearInterval(cleanupInterval)
+        cleanupInterval = null
     }
 }

--- a/src/lib/webhook-processor.ts
+++ b/src/lib/webhook-processor.ts
@@ -1,0 +1,189 @@
+import { db, Tables } from './db'
+import pendingWebhookEvents, {
+    PendingWebhookEvent,
+} from '../services/pending-webhook-events'
+import deploymentsService from '../services/deployments'
+import { sendDeploymentEmail } from './nylas-mailer'
+
+// How often the in-process poller wakes up to check for due retries.
+// The first attempt for any event happens inline in the request handler,
+// so this interval only affects retry latency after a failure.
+const POLL_INTERVAL_MS = 60_000
+
+const BATCH_SIZE = 10
+
+export type WebhookEventType = 'deployment'
+
+export interface DeploymentEventPayload {
+    website_id: string
+    changed_urls: string[]
+    deploy_summary: string
+    internal_notes?: string
+}
+
+// Thrown by processors when the error is permanent and no retry should be
+// attempted (e.g. the referenced website no longer exists). Causes the event
+// to be marked 'failed' immediately rather than scheduled for retry.
+export class NonRetryableWebhookError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'NonRetryableWebhookError'
+    }
+}
+
+/**
+ * Process a deployment event: verify the website, create the deployment row,
+ * send the notification email. Returns the new deployment id on success.
+ *
+ * Email failures are swallowed (same behavior as the pre-DEV-701 controller)
+ * because the deployment record itself is the thing we cannot recover — once
+ * it's in the DB, the client-facing data is safe even if the email bounces.
+ */
+export const processDeploymentEvent = async (
+    payload: DeploymentEventPayload,
+): Promise<string> => {
+    const { website_id, changed_urls, deploy_summary, internal_notes } = payload
+
+    const { data: website, error: websiteError } = await db
+        .from(Tables.WEBSITES)
+        .select('id, title, contact_email, client_id')
+        .eq('id', website_id)
+        .single()
+
+    if (websiteError || !website) {
+        throw new NonRetryableWebhookError(
+            `Website not found for deployment event: ${website_id}`,
+        )
+    }
+
+    const deployment = await deploymentsService.createDeployment({
+        website_id,
+        changed_urls,
+        deploy_summary,
+        internal_notes,
+    })
+
+    if (website.contact_email) {
+        try {
+            await sendDeploymentEmail({
+                to: website.contact_email,
+                websiteTitle: website.title,
+                deploymentDate: new Date(
+                    deployment.created_at,
+                ).toLocaleDateString(),
+                summaryMarkdown: deploy_summary,
+            })
+            console.log(
+                '✅ Deployment email sent:',
+                website.contact_email,
+                'for',
+                website.title,
+            )
+        } catch (emailError) {
+            console.error(
+                '❌ Error sending deployment email (non-fatal):',
+                emailError,
+            )
+        }
+    }
+
+    return deployment.id
+}
+
+const runProcessor = async (
+    event: PendingWebhookEvent,
+): Promise<string | null> => {
+    switch (event.event_type as WebhookEventType) {
+        case 'deployment':
+            return processDeploymentEvent(
+                event.payload as unknown as DeploymentEventPayload,
+            )
+        default:
+            throw new NonRetryableWebhookError(
+                `Unknown event_type: ${event.event_type}`,
+            )
+    }
+}
+
+/**
+ * Process a single pending event. Used both by the inline path (first attempt
+ * inside the request handler) and by the poller (scheduled retries).
+ *
+ * Returns true on success, false on failure (the row is updated accordingly).
+ */
+export const processEvent = async (
+    event: PendingWebhookEvent,
+): Promise<boolean> => {
+    const attempts = event.attempts + 1
+    try {
+        const resultRef = await runProcessor(event)
+        await pendingWebhookEvents.markDone(event.id, attempts, resultRef)
+        return true
+    } catch (err) {
+        const isNonRetryable = err instanceof NonRetryableWebhookError
+        const message = err instanceof Error ? err.message : String(err)
+
+        if (isNonRetryable) {
+            console.error(
+                `❌ webhook event ${event.id} failed permanently:`,
+                message,
+            )
+            await pendingWebhookEvents.scheduleNextRetry(
+                event.id,
+                Number.MAX_SAFE_INTEGER,
+                `[non-retryable] ${message}`,
+            )
+            return false
+        }
+
+        console.error(
+            `⚠️  webhook event ${event.id} attempt ${attempts} failed:`,
+            message,
+        )
+        await pendingWebhookEvents.scheduleNextRetry(
+            event.id,
+            attempts,
+            message,
+        )
+        return false
+    }
+}
+
+let processorInterval: NodeJS.Timeout | null = null
+let processorRunning = false
+
+const tick = async () => {
+    if (processorRunning) return
+    processorRunning = true
+    try {
+        const due = await pendingWebhookEvents.fetchDue(BATCH_SIZE)
+        if (due.length === 0) return
+
+        console.log(`🔁 webhook-processor: processing ${due.length} due event(s)`)
+        for (const event of due) {
+            await processEvent(event)
+        }
+    } catch (err) {
+        console.error('❌ webhook-processor tick failed:', err)
+    } finally {
+        processorRunning = false
+    }
+}
+
+export const startWebhookProcessor = (): void => {
+    if (processorInterval) return
+    processorInterval = setInterval(tick, POLL_INTERVAL_MS)
+    // Run one tick shortly after boot to pick up rows that were pending when
+    // the server last died, without waiting a full interval.
+    setTimeout(tick, 5_000)
+    console.log(
+        `🚀 webhook-processor started (interval ${POLL_INTERVAL_MS}ms, batch ${BATCH_SIZE})`,
+    )
+}
+
+export const stopWebhookProcessor = (): void => {
+    if (processorInterval) {
+        clearInterval(processorInterval)
+        processorInterval = null
+    }
+}

--- a/src/routes/deployments.ts
+++ b/src/routes/deployments.ts
@@ -3,6 +3,7 @@ import { body, param, query } from 'express-validator'
 
 import { validateRequest } from './middleware'
 import deployments from '../controllers/deployments'
+import { webhookWriteLimit } from './rate-limits'
 
 const router = Router()
 
@@ -12,24 +13,35 @@ const statusValidator = body('status')
     .withMessage('status must be either "requested" or "indexed"')
 
 // POST /api/deployments - Create a new deployment record
+// Called by client CI/CD pipelines post-deploy. Public endpoint; field
+// length caps + webhookWriteLimit protect the queue table from abuse.
 router.post(
     '/api/deployments',
+    webhookWriteLimit,
     [
         body('website_id')
             .isUUID()
             .withMessage('website_id must be a valid UUID'),
         body('changed_urls')
-            .isArray({ min: 1 })
-            .withMessage('changed_urls must be a non-empty array'),
-        body('changed_urls.*').isURL().withMessage('Each URL must be valid'),
+            .isArray({ min: 1, max: 500 })
+            .withMessage('changed_urls must be between 1 and 500 items'),
+        body('changed_urls.*')
+            .isURL()
+            .withMessage('Each URL must be valid')
+            .isLength({ max: 2048 })
+            .withMessage('Each URL must be 2048 characters or less'),
         body('deploy_summary')
             .isString()
             .notEmpty()
-            .withMessage('deploy_summary is required and must be markdown'),
+            .withMessage('deploy_summary is required and must be markdown')
+            .isLength({ max: 20000 })
+            .withMessage('deploy_summary must be 20000 characters or less'),
         body('internal_notes')
             .optional()
             .isString()
             .withMessage('internal_notes must be a string if provided')
+            .isLength({ max: 5000 })
+            .withMessage('internal_notes must be 5000 characters or less')
     ],
     validateRequest,
     deployments.create

--- a/src/routes/rate-limits.ts
+++ b/src/routes/rate-limits.ts
@@ -151,6 +151,20 @@ export const sensitiveWriteLimit = rateLimit({
 })
 
 /**
+ * Public write endpoints that persist durable state from unauthenticated
+ * callers (currently POST /api/deployments from client CI/CD). Stricter
+ * than the general limiter because each accepted request creates a row
+ * in `pending_webhook_events` even when processing fails; abuse would
+ * bloat the queue table. Keyed by IP via safeIpKey.
+ */
+export const webhookWriteLimit = rateLimit({
+    ...baseConfig,
+    windowMs: ONE_MINUTE,
+    max: 10,
+    keyGenerator: safeIpKey,
+})
+
+/**
  * Catch-all default applied at the app level for non-CMS routes.
  * Loose enough not to interfere with normal traffic but tight enough
  * to blunt simple flooding attacks. Keyed by IP.

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import cmsPagesRouter from './routes/cms-pages'
 import websiteDomainsRouter from './routes/website-domains'
 import r2UploadsRouter from './routes/r2-uploads'
 import { generalApiLimit } from './routes/rate-limits'
+import { startWebhookProcessor } from './lib/webhook-processor'
 
 import 'dotenv/config'
 
@@ -84,4 +85,5 @@ app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)
     console.log(`trust proxy: ${app.get('trust proxy')}`)
     console.log(`environment: ${process.env.NODE_ENVIRONMENT || 'not set'}`)
+    startWebhookProcessor()
 })

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,7 +91,10 @@ const server = app.listen(PORT, () => {
     startWebhookProcessor()
 })
 
+let shuttingDown = false
 const shutdown = (signal: string) => {
+    if (shuttingDown) return
+    shuttingDown = true
     console.log(`Received ${signal}, shutting down...`)
     stopWebhookProcessor()
     server.close(() => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,10 @@ import cmsPagesRouter from './routes/cms-pages'
 import websiteDomainsRouter from './routes/website-domains'
 import r2UploadsRouter from './routes/r2-uploads'
 import { generalApiLimit } from './routes/rate-limits'
-import { startWebhookProcessor } from './lib/webhook-processor'
+import {
+    startWebhookProcessor,
+    stopWebhookProcessor,
+} from './lib/webhook-processor'
 
 import 'dotenv/config'
 
@@ -81,9 +84,26 @@ app.use(
 )
 
 // Start the server
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)
     console.log(`trust proxy: ${app.get('trust proxy')}`)
     console.log(`environment: ${process.env.NODE_ENVIRONMENT || 'not set'}`)
     startWebhookProcessor()
 })
+
+const shutdown = (signal: string) => {
+    console.log(`Received ${signal}, shutting down...`)
+    stopWebhookProcessor()
+    server.close(() => {
+        console.log('HTTP server closed.')
+        process.exit(0)
+    })
+    // Hard-exit if graceful close hangs (e.g. open sockets).
+    setTimeout(() => {
+        console.error('Forced exit after shutdown timeout')
+        process.exit(1)
+    }, 10_000).unref()
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+process.on('SIGINT', () => shutdown('SIGINT'))

--- a/src/services/pending-webhook-events.ts
+++ b/src/services/pending-webhook-events.ts
@@ -17,24 +17,56 @@ export interface PendingWebhookEvent {
 
 // Retry schedule for failed attempts. Index 0 is used after the first failure,
 // index 1 after the second, and so on. Once attempts exceeds the array length,
-// the event is marked 'failed' and no further retries are scheduled.
+// the event is marked 'failed' via markFailed() — scheduleNextRetry no longer
+// encodes the "give up" decision.
 const RETRY_DELAYS_SECONDS = [60, 300, 1800]
 
 export const MAX_ATTEMPTS = RETRY_DELAYS_SECONDS.length + 1
 
+// ±25% jitter on scheduled retries to prevent thundering herd when many
+// events fail at the same moment (e.g. transient DB outage) and would
+// otherwise all wake up on the exact same tick.
+const jitter = (seconds: number): number => {
+    const factor = 0.75 + Math.random() * 0.5
+    return Math.round(seconds * factor)
+}
+
+/**
+ * Error taxonomy stored in last_error. Keeping this a small closed set
+ * means the column never contains raw supabase/nylas error strings that
+ * could leak schema hints, API response snippets, or connection details.
+ * Raw errors are still console.error'd for operators.
+ */
+export const ErrorReasons = {
+    WEBSITE_NOT_FOUND: 'website_not_found',
+    DB_INSERT_FAILED: 'db_insert_failed',
+    EMAIL_SEND_FAILED: 'email_send_failed',
+    UNKNOWN: 'unknown',
+} as const
+
+export type ErrorReason = (typeof ErrorReasons)[keyof typeof ErrorReasons]
+
+/**
+ * Insert a fresh event row. `initialDelayMs` pushes next_retry_at into the
+ * future so the background poller cannot claim the row while the inline
+ * handler is still processing it (otherwise double-processing is possible
+ * when the inline attempt is slow).
+ */
 const insertPending = async (
-    event_type: string,
+    eventType: string,
     payload: Record<string, unknown>,
+    initialDelayMs: number,
 ): Promise<PendingWebhookEvent> => {
+    const nextRetryAt = new Date(Date.now() + initialDelayMs).toISOString()
     const { data, error } = await db
         .from(Tables.PENDING_WEBHOOK_EVENTS)
         .insert([
             {
-                event_type,
+                event_type: eventType,
                 payload,
                 status: 'pending',
                 attempts: 0,
-                next_retry_at: new Date().toISOString(),
+                next_retry_at: nextRetryAt,
             },
         ])
         .select()
@@ -44,10 +76,25 @@ const insertPending = async (
     return data as PendingWebhookEvent
 }
 
+/**
+ * Record that the downstream record was created so an idempotent retry
+ * (after a crash between createDeployment and markDone) will not
+ * re-create it. Called inside processDeploymentEvent immediately after
+ * the website_deployments row is persisted, *before* the email send.
+ */
+const setResultRef = async (id: string, resultRef: string): Promise<void> => {
+    const { error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .update({ result_ref: resultRef })
+        .eq('id', id)
+
+    if (error) throw error
+}
+
 const markDone = async (
     id: string,
     attempts: number,
-    result_ref?: string | null,
+    resultRef?: string | null,
 ): Promise<void> => {
     const { error } = await db
         .from(Tables.PENDING_WEBHOOK_EVENTS)
@@ -55,7 +102,7 @@ const markDone = async (
             status: 'done',
             attempts,
             processed_at: new Date().toISOString(),
-            result_ref: result_ref ?? null,
+            result_ref: resultRef ?? null,
             last_error: null,
         })
         .eq('id', id)
@@ -63,45 +110,65 @@ const markDone = async (
     if (error) throw error
 }
 
+/**
+ * Terminal failure — no further retries will be attempted. Use this for
+ * permanent errors (e.g. website deleted) and for the final attempt after
+ * the retry schedule is exhausted.
+ */
+const markFailed = async (
+    id: string,
+    attempts: number,
+    reason: ErrorReason,
+): Promise<void> => {
+    const { error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .update({
+            status: 'failed',
+            attempts,
+            last_error: reason,
+            processed_at: new Date().toISOString(),
+        })
+        .eq('id', id)
+
+    if (error) throw error
+}
+
+/**
+ * Schedule the next retry attempt. `attempts` is the total number of
+ * attempts made so far *including the one that just failed* (so on the
+ * first failure attempts=1, on the second attempts=2, etc.).
+ *
+ * Returns true if a retry was scheduled, false if the retry budget is
+ * exhausted and the caller should invoke markFailed.
+ */
 const scheduleNextRetry = async (
     id: string,
     attempts: number,
-    errorMessage: string,
-): Promise<{ status: PendingWebhookStatus; next_retry_at: string | null }> => {
-    // attempts is the number of attempts made so far (including the one that
-    // just failed). The next delay is indexed by attempts - 1 because the first
-    // failure uses RETRY_DELAYS_SECONDS[0].
+    reason: ErrorReason,
+): Promise<{ scheduled: boolean; nextRetryAt: string | null }> => {
     const delayIndex = attempts - 1
     const delaySeconds = RETRY_DELAYS_SECONDS[delayIndex]
 
     if (delaySeconds === undefined) {
-        const { error } = await db
-            .from(Tables.PENDING_WEBHOOK_EVENTS)
-            .update({
-                status: 'failed',
-                attempts,
-                last_error: errorMessage,
-                processed_at: new Date().toISOString(),
-            })
-            .eq('id', id)
-
-        if (error) throw error
-        return { status: 'failed', next_retry_at: null }
+        return { scheduled: false, nextRetryAt: null }
     }
 
-    const nextRetry = new Date(Date.now() + delaySeconds * 1000).toISOString()
+    const nextRetryAt = new Date(
+        Date.now() + jitter(delaySeconds) * 1000,
+    ).toISOString()
+
     const { error } = await db
         .from(Tables.PENDING_WEBHOOK_EVENTS)
         .update({
             status: 'pending',
             attempts,
-            last_error: errorMessage,
-            next_retry_at: nextRetry,
+            last_error: reason,
+            next_retry_at: nextRetryAt,
         })
         .eq('id', id)
 
     if (error) throw error
-    return { status: 'pending', next_retry_at: nextRetry }
+    return { scheduled: true, nextRetryAt }
 }
 
 const fetchDue = async (limit: number): Promise<PendingWebhookEvent[]> => {
@@ -118,10 +185,65 @@ const fetchDue = async (limit: number): Promise<PendingWebhookEvent[]> => {
     return (data || []) as PendingWebhookEvent[]
 }
 
+/**
+ * Hard-delete an event row. Used when the payload is garbage (e.g. the
+ * controller's pre-validation caught a non-existent website_id) so it
+ * never permanently bloats the queue table.
+ */
+const deleteEvent = async (id: string): Promise<void> => {
+    const { error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .delete()
+        .eq('id', id)
+
+    if (error) throw error
+}
+
+/**
+ * Cleanup old processed rows so the queue table does not grow without
+ * bound. Called periodically by the webhook processor; not on the
+ * request hot path.
+ */
+const cleanupOldEvents = async (): Promise<{
+    done: number
+    failed: number
+}> => {
+    const doneCutoff = new Date(
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
+    ).toISOString()
+    const failedCutoff = new Date(
+        Date.now() - 90 * 24 * 60 * 60 * 1000,
+    ).toISOString()
+
+    const doneResult = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .delete({ count: 'exact' })
+        .eq('status', 'done')
+        .lt('processed_at', doneCutoff)
+
+    const failedResult = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .delete({ count: 'exact' })
+        .eq('status', 'failed')
+        .lt('processed_at', failedCutoff)
+
+    if (doneResult.error) throw doneResult.error
+    if (failedResult.error) throw failedResult.error
+
+    return {
+        done: doneResult.count ?? 0,
+        failed: failedResult.count ?? 0,
+    }
+}
+
 export default {
     insertPending,
+    setResultRef,
     markDone,
+    markFailed,
     scheduleNextRetry,
     fetchDue,
+    deleteEvent,
+    cleanupOldEvents,
     RETRY_DELAYS_SECONDS,
 }

--- a/src/services/pending-webhook-events.ts
+++ b/src/services/pending-webhook-events.ts
@@ -11,6 +11,7 @@ export interface PendingWebhookEvent {
     next_retry_at: string
     last_error: string | null
     result_ref: string | null
+    email_sent_at: string | null
     created_at: string
     processed_at: string | null
 }
@@ -20,8 +21,6 @@ export interface PendingWebhookEvent {
 // the event is marked 'failed' via markFailed() — scheduleNextRetry no longer
 // encodes the "give up" decision.
 const RETRY_DELAYS_SECONDS = [60, 300, 1800]
-
-export const MAX_ATTEMPTS = RETRY_DELAYS_SECONDS.length + 1
 
 // ±25% jitter on scheduled retries to prevent thundering herd when many
 // events fail at the same moment (e.g. transient DB outage) and would
@@ -86,6 +85,21 @@ const setResultRef = async (id: string, resultRef: string): Promise<void> => {
     const { error } = await db
         .from(Tables.PENDING_WEBHOOK_EVENTS)
         .update({ result_ref: resultRef })
+        .eq('id', id)
+
+    if (error) throw error
+}
+
+/**
+ * Record that the notification email for this event succeeded. Retries
+ * check this column and skip the email send when set, preventing the
+ * client from receiving the same notification twice if a crash occurs
+ * after sendEmail succeeds but before markDone.
+ */
+const setEmailSent = async (id: string): Promise<void> => {
+    const { error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .update({ email_sent_at: new Date().toISOString() })
         .eq('id', id)
 
     if (error) throw error
@@ -239,6 +253,7 @@ const cleanupOldEvents = async (): Promise<{
 export default {
     insertPending,
     setResultRef,
+    setEmailSent,
     markDone,
     markFailed,
     scheduleNextRetry,

--- a/src/services/pending-webhook-events.ts
+++ b/src/services/pending-webhook-events.ts
@@ -2,10 +2,15 @@ import { db, Tables } from '../lib/db'
 
 export type PendingWebhookStatus = 'pending' | 'done' | 'failed'
 
-export interface PendingWebhookEvent {
+/**
+ * Queue row shape. `payload` is typed via the generic parameter so consumers
+ * that know the event type can avoid the `as unknown as T` dance. Defaults
+ * to an opaque record for callers that don't care.
+ */
+export interface PendingWebhookEvent<P = Record<string, unknown>> {
     id: string
     event_type: string
-    payload: Record<string, unknown>
+    payload: P
     status: PendingWebhookStatus
     attempts: number
     next_retry_at: string
@@ -16,10 +21,6 @@ export interface PendingWebhookEvent {
     processed_at: string | null
 }
 
-// Retry schedule for failed attempts. Index 0 is used after the first failure,
-// index 1 after the second, and so on. Once attempts exceeds the array length,
-// the event is marked 'failed' via markFailed() — scheduleNextRetry no longer
-// encodes the "give up" decision.
 const RETRY_DELAYS_SECONDS = [60, 300, 1800]
 
 // ±25% jitter on scheduled retries to prevent thundering herd when many
@@ -35,6 +36,10 @@ const jitter = (seconds: number): number => {
  * means the column never contains raw supabase/nylas error strings that
  * could leak schema hints, API response snippets, or connection details.
  * Raw errors are still console.error'd for operators.
+ *
+ * Note: `last_error` on a `status='done'` row is a non-fatal warning (e.g.
+ * deployment row was created but the notification email failed). Operator
+ * query for "done but degraded" events: `WHERE status='done' AND last_error IS NOT NULL`.
  */
 export const ErrorReasons = {
     WEBSITE_NOT_FOUND: 'website_not_found',
@@ -46,16 +51,48 @@ export const ErrorReasons = {
 export type ErrorReason = (typeof ErrorReasons)[keyof typeof ErrorReasons]
 
 /**
+ * Best-effort retry wrapper for transient DB bookkeeping writes (setResultRef,
+ * setEmailSent). These writes happen AFTER user-facing work has already
+ * succeeded, so a single transient Supabase failure cannot be allowed to
+ * cascade into "retry the whole event" (which would duplicate the user-facing
+ * work). Retries linearly for up to ~2s total before giving up.
+ */
+const withRetries = async <T>(
+    label: string,
+    fn: () => Promise<T>,
+    attempts = 3,
+): Promise<T> => {
+    let lastErr: unknown
+    for (let i = 0; i < attempts; i++) {
+        try {
+            return await fn()
+        } catch (err) {
+            lastErr = err
+            if (i < attempts - 1) {
+                await new Promise(resolve =>
+                    setTimeout(resolve, 200 * (i + 1)),
+                )
+            }
+        }
+    }
+    console.error(
+        `❌ ${label} failed after ${attempts} attempts:`,
+        lastErr,
+    )
+    throw lastErr
+}
+
+/**
  * Insert a fresh event row. `initialDelayMs` pushes next_retry_at into the
  * future so the background poller cannot claim the row while the inline
  * handler is still processing it (otherwise double-processing is possible
  * when the inline attempt is slow).
  */
-const insertPending = async (
+const insertPending = async <P extends Record<string, unknown>>(
     eventType: string,
-    payload: Record<string, unknown>,
+    payload: P,
     initialDelayMs: number,
-): Promise<PendingWebhookEvent> => {
+): Promise<PendingWebhookEvent<P>> => {
     const nextRetryAt = new Date(Date.now() + initialDelayMs).toISOString()
     const { data, error } = await db
         .from(Tables.PENDING_WEBHOOK_EVENTS)
@@ -72,43 +109,52 @@ const insertPending = async (
         .single()
 
     if (error) throw error
-    return data as PendingWebhookEvent
+    return data as PendingWebhookEvent<P>
 }
 
 /**
  * Record that the downstream record was created so an idempotent retry
- * (after a crash between createDeployment and markDone) will not
- * re-create it. Called inside processDeploymentEvent immediately after
- * the website_deployments row is persisted, *before* the email send.
+ * (after a crash between createDeployment and markDone) will not re-create
+ * it. Wrapped in withRetries because this write happens AFTER a successful
+ * user-facing side effect — a transient failure here cannot be allowed to
+ * trigger a duplicate of that side effect.
  */
 const setResultRef = async (id: string, resultRef: string): Promise<void> => {
-    const { error } = await db
-        .from(Tables.PENDING_WEBHOOK_EVENTS)
-        .update({ result_ref: resultRef })
-        .eq('id', id)
-
-    if (error) throw error
+    await withRetries(`setResultRef(${id})`, async () => {
+        const { error } = await db
+            .from(Tables.PENDING_WEBHOOK_EVENTS)
+            .update({ result_ref: resultRef })
+            .eq('id', id)
+        if (error) throw error
+    })
 }
 
 /**
- * Record that the notification email for this event succeeded. Retries
- * check this column and skip the email send when set, preventing the
- * client from receiving the same notification twice if a crash occurs
- * after sendEmail succeeds but before markDone.
+ * Record that the notification email succeeded. Retries check this column
+ * and skip the email block when set, preventing duplicate notifications if
+ * a crash happens after sendEmail succeeds but before markDone. Wrapped
+ * in withRetries for the same reason as setResultRef.
  */
 const setEmailSent = async (id: string): Promise<void> => {
-    const { error } = await db
-        .from(Tables.PENDING_WEBHOOK_EVENTS)
-        .update({ email_sent_at: new Date().toISOString() })
-        .eq('id', id)
-
-    if (error) throw error
+    await withRetries(`setEmailSent(${id})`, async () => {
+        const { error } = await db
+            .from(Tables.PENDING_WEBHOOK_EVENTS)
+            .update({ email_sent_at: new Date().toISOString() })
+            .eq('id', id)
+        if (error) throw error
+    })
 }
 
+/**
+ * Mark the event as successfully processed. `warning` optionally persists
+ * a last_error marker on an otherwise-successful event (e.g. deployment
+ * row created but email bounced). Leave undefined for a clean success.
+ */
 const markDone = async (
     id: string,
     attempts: number,
-    resultRef?: string | null,
+    resultRef: string,
+    warning?: ErrorReason,
 ): Promise<void> => {
     const { error } = await db
         .from(Tables.PENDING_WEBHOOK_EVENTS)
@@ -116,8 +162,8 @@ const markDone = async (
             status: 'done',
             attempts,
             processed_at: new Date().toISOString(),
-            result_ref: resultRef ?? null,
-            last_error: null,
+            result_ref: resultRef,
+            last_error: warning ?? null,
         })
         .eq('id', id)
 
@@ -149,11 +195,12 @@ const markFailed = async (
 
 /**
  * Schedule the next retry attempt. `attempts` is the total number of
- * attempts made so far *including the one that just failed* (so on the
- * first failure attempts=1, on the second attempts=2, etc.).
+ * attempts made so far *including the one that just failed* (on the first
+ * failure attempts=1, on the second attempts=2, etc.).
  *
- * Returns true if a retry was scheduled, false if the retry budget is
- * exhausted and the caller should invoke markFailed.
+ * Returns `scheduled=true` if a retry was scheduled, `scheduled=false`
+ * when the retry budget is exhausted and the caller should invoke
+ * markFailed.
  */
 const scheduleNextRetry = async (
     id: string,
@@ -197,20 +244,6 @@ const fetchDue = async (limit: number): Promise<PendingWebhookEvent[]> => {
 
     if (error) throw error
     return (data || []) as PendingWebhookEvent[]
-}
-
-/**
- * Hard-delete an event row. Used when the payload is garbage (e.g. the
- * controller's pre-validation caught a non-existent website_id) so it
- * never permanently bloats the queue table.
- */
-const deleteEvent = async (id: string): Promise<void> => {
-    const { error } = await db
-        .from(Tables.PENDING_WEBHOOK_EVENTS)
-        .delete()
-        .eq('id', id)
-
-    if (error) throw error
 }
 
 /**
@@ -258,7 +291,6 @@ export default {
     markFailed,
     scheduleNextRetry,
     fetchDue,
-    deleteEvent,
     cleanupOldEvents,
     RETRY_DELAYS_SECONDS,
 }

--- a/src/services/pending-webhook-events.ts
+++ b/src/services/pending-webhook-events.ts
@@ -1,0 +1,127 @@
+import { db, Tables } from '../lib/db'
+
+export type PendingWebhookStatus = 'pending' | 'done' | 'failed'
+
+export interface PendingWebhookEvent {
+    id: string
+    event_type: string
+    payload: Record<string, unknown>
+    status: PendingWebhookStatus
+    attempts: number
+    next_retry_at: string
+    last_error: string | null
+    result_ref: string | null
+    created_at: string
+    processed_at: string | null
+}
+
+// Retry schedule for failed attempts. Index 0 is used after the first failure,
+// index 1 after the second, and so on. Once attempts exceeds the array length,
+// the event is marked 'failed' and no further retries are scheduled.
+const RETRY_DELAYS_SECONDS = [60, 300, 1800]
+
+export const MAX_ATTEMPTS = RETRY_DELAYS_SECONDS.length + 1
+
+const insertPending = async (
+    event_type: string,
+    payload: Record<string, unknown>,
+): Promise<PendingWebhookEvent> => {
+    const { data, error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .insert([
+            {
+                event_type,
+                payload,
+                status: 'pending',
+                attempts: 0,
+                next_retry_at: new Date().toISOString(),
+            },
+        ])
+        .select()
+        .single()
+
+    if (error) throw error
+    return data as PendingWebhookEvent
+}
+
+const markDone = async (
+    id: string,
+    attempts: number,
+    result_ref?: string | null,
+): Promise<void> => {
+    const { error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .update({
+            status: 'done',
+            attempts,
+            processed_at: new Date().toISOString(),
+            result_ref: result_ref ?? null,
+            last_error: null,
+        })
+        .eq('id', id)
+
+    if (error) throw error
+}
+
+const scheduleNextRetry = async (
+    id: string,
+    attempts: number,
+    errorMessage: string,
+): Promise<{ status: PendingWebhookStatus; next_retry_at: string | null }> => {
+    // attempts is the number of attempts made so far (including the one that
+    // just failed). The next delay is indexed by attempts - 1 because the first
+    // failure uses RETRY_DELAYS_SECONDS[0].
+    const delayIndex = attempts - 1
+    const delaySeconds = RETRY_DELAYS_SECONDS[delayIndex]
+
+    if (delaySeconds === undefined) {
+        const { error } = await db
+            .from(Tables.PENDING_WEBHOOK_EVENTS)
+            .update({
+                status: 'failed',
+                attempts,
+                last_error: errorMessage,
+                processed_at: new Date().toISOString(),
+            })
+            .eq('id', id)
+
+        if (error) throw error
+        return { status: 'failed', next_retry_at: null }
+    }
+
+    const nextRetry = new Date(Date.now() + delaySeconds * 1000).toISOString()
+    const { error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .update({
+            status: 'pending',
+            attempts,
+            last_error: errorMessage,
+            next_retry_at: nextRetry,
+        })
+        .eq('id', id)
+
+    if (error) throw error
+    return { status: 'pending', next_retry_at: nextRetry }
+}
+
+const fetchDue = async (limit: number): Promise<PendingWebhookEvent[]> => {
+    const now = new Date().toISOString()
+    const { data, error } = await db
+        .from(Tables.PENDING_WEBHOOK_EVENTS)
+        .select('*')
+        .eq('status', 'pending')
+        .lte('next_retry_at', now)
+        .order('next_retry_at', { ascending: true })
+        .limit(limit)
+
+    if (error) throw error
+    return (data || []) as PendingWebhookEvent[]
+}
+
+export default {
+    insertPending,
+    markDone,
+    scheduleNextRetry,
+    fetchDue,
+    RETRY_DELAYS_SECONDS,
+}

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,14 @@
+/**
+ * Compile-time exhaustiveness check for discriminated unions. Call in the
+ * default branch of an if/else or switch on a union's discriminator; if a
+ * new variant is added later, the `never` typing will produce a type error
+ * at the call site — forcing the author to handle the new case.
+ *
+ * Runtime fallback throws so a mis-built consumer also fails loudly in
+ * production rather than silently ignoring the new variant.
+ */
+export const assertNever = (value: never): never => {
+    throw new Error(
+        `unexpected variant: ${JSON.stringify(value)}`,
+    )
+}

--- a/supabase/migrations/20260414_create_pending_webhook_events.sql
+++ b/supabase/migrations/20260414_create_pending_webhook_events.sql
@@ -1,0 +1,33 @@
+-- DEV-701: Deploy-window resilience for irrecoverable webhook payloads.
+-- Durable queue for webhook payloads (currently only POST /api/deployments).
+-- Insert-first, process-second pattern: the payload is persisted before any
+-- fallible processing runs, so server crashes or mid-handler failures can
+-- resume work from this table instead of dropping client data.
+
+CREATE TABLE IF NOT EXISTS public.pending_webhook_events (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type      TEXT NOT NULL,
+    payload         JSONB NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'pending',
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    next_retry_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_error      TEXT,
+    result_ref      UUID,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at    TIMESTAMPTZ,
+    CONSTRAINT chk_status CHECK (status IN ('pending', 'done', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_webhook_events_due
+    ON public.pending_webhook_events(next_retry_at)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_pending_webhook_events_event_type
+    ON public.pending_webhook_events(event_type, status);
+
+COMMENT ON TABLE public.pending_webhook_events IS
+    'Durable queue for webhook payloads that cannot be recovered if dropped (e.g. client CI/CD deploy summaries). See DEV-701.';
+COMMENT ON COLUMN public.pending_webhook_events.event_type IS
+    'Discriminator for the payload shape. Currently: deployment.';
+COMMENT ON COLUMN public.pending_webhook_events.result_ref IS
+    'FK-like reference to the successfully-created downstream record (e.g. website_deployments.id) for traceability.';

--- a/supabase/migrations/20260414b_tune_pending_webhook_events.sql
+++ b/supabase/migrations/20260414b_tune_pending_webhook_events.sql
@@ -1,0 +1,7 @@
+-- DEV-701 follow-up: drop the unused (event_type, status) index.
+-- The poller's only hot query is `status='pending' AND next_retry_at<=now`,
+-- which is served by idx_pending_webhook_events_due. No current query
+-- filters by event_type, so the second index just adds write overhead.
+-- Recreate it if/when an admin dashboard queries the table by type.
+
+DROP INDEX IF EXISTS public.idx_pending_webhook_events_event_type;

--- a/supabase/migrations/20260414c_pending_webhook_events_email_sent.sql
+++ b/supabase/migrations/20260414c_pending_webhook_events_email_sent.sql
@@ -1,0 +1,11 @@
+-- DEV-701 follow-up: prevent duplicate email on retry.
+-- If processDeploymentEvent sends the email successfully but crashes
+-- before markDone, the next retry would re-send the same email.
+-- Tracking email_sent_at lets the processor skip the email block on
+-- retry when it already succeeded.
+
+ALTER TABLE public.pending_webhook_events
+    ADD COLUMN IF NOT EXISTS email_sent_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.pending_webhook_events.email_sent_at IS
+    'Set when the notification email succeeded. Retries skip the email send when non-null. See DEV-701.';


### PR DESCRIPTION
## Summary

- Adds a durable queue (`pending_webhook_events`) for irrecoverable webhook payloads so client CI/CD deploy summaries survive server restarts and handler-internal failures
- Flips `POST /api/deployments` to insert-first, process-second: the payload is persisted before any fallible work runs
- In-process poller retries failed events at 1m → 5m → 30m, then marks `failed` and logs loudly
- Audits the other 4 public webhooks (`leads`, `contact-forms`, `audit-requests`, `calendly-webhook`) and documents why none warrant the same treatment
- Adds a deploy-window runbook covering pre-merge / post-merge checks and incident response

Ticket: https://linear.app/pixelverse-studios/issue/DEV-701

## What changed

**New**
- `supabase/migrations/20260414_create_pending_webhook_events.sql` — queue table + indexes
- `src/services/pending-webhook-events.ts` — service layer (insert / markDone / scheduleNextRetry / fetchDue)
- `src/lib/webhook-processor.ts` — per-event processor + `setInterval` poller started from `server.ts`
- `docs/audits/webhook-durability-audit.md`
- `docs/runbooks/deploy-window.md`

**Modified**
- `src/controllers/deployments.ts` — insert-first handler; returns 201 on inline success, 202 on queued-for-retry
- `src/lib/db.ts` — adds `PENDING_WEBHOOK_EVENTS` to `Tables`
- `src/server.ts` — starts the poller on boot

## Response-code note

Clients are all fire-and-forget and don't read back, so the new 202-on-queued path is zero-impact externally. Internal consumers (none today) should still treat 2xx as success.

## Test plan

- [ ] Run migration against dev Supabase, confirm table + indexes created
- [ ] Run migration against prod Supabase
- [ ] Local smoke test on port 5002: valid payload → 201 with deployment record; bad `website_id` → event written, marked `failed` (non-retryable)
- [ ] Simulated inline failure (e.g. point Nylas at a bad key) → 202 queued, observe retry + eventual success/failure in `pending_webhook_events`
- [ ] Verify `🚀 webhook-processor started` log line on boot
- [ ] Deploy to production, watch logs for 10 minutes

## Residual risk

The queue does not cover the ~1s window where the Node process is fully down between deploys. The runbook addresses this via scheduling discipline (avoid known client deploy windows) and a post-merge verification checklist. The known-windows table in the runbook is intentionally left as a TODO to fill in from operational knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)