### PR TITLE
Fix contact form error handling

### DIFF
--- a/src/controllers/contact-forms.ts
+++ b/src/controllers/contact-forms.ts
@@ -42,14 +42,22 @@ const addRecord = async (req: Request, res: Response): Promise<Response> => {
             data: payload.additional,
         })
 
-        await sendEmail({
-            to:
-                process.env.NODE_ENVIRONMENT === 'development'
-                    ? 'info@pixelversestudios.io'
-                    : sendToEmail,
-            subject: `New Contact Form Submission for ${title}`,
-            html,
-        })
+        try {
+            await sendEmail({
+                to:
+                    process.env.NODE_ENVIRONMENT === 'development'
+                        ? 'info@pixelversestudios.io'
+                        : sendToEmail,
+                subject: `New Contact Form Submission for ${title}`,
+                html,
+            })
+        } catch (emailError) {
+            console.error('Contact form notification email failed:', {
+                website_slug,
+                website_id,
+                emailError
+            })
+        }
 
         return res.status(201).json({})
     } catch (err) {

--- a/src/routes/contact-forms.ts
+++ b/src/routes/contact-forms.ts
@@ -12,11 +12,44 @@ contactFormsRouter.get(BASE_ROUTE, contactForms.getAll)
 contactFormsRouter.post(
     `${BASE_ROUTE}/:website_slug`,
     [
-        param('website_slug').isString().notEmpty(),
-        body('fullname').isString().notEmpty(),
-        body('email').isString().notEmpty(),
-        body('phone').optional().isString(),
-        body('data').notEmpty().isObject()
+        param('website_slug')
+            .isString()
+            .withMessage('website_slug must be a string')
+            .bail()
+            .trim()
+            .notEmpty()
+            .withMessage('website_slug is required'),
+        body('fullname')
+            .isString()
+            .withMessage('fullname must be a string')
+            .bail()
+            .trim()
+            .notEmpty()
+            .withMessage('fullname is required'),
+        body('email')
+            .isString()
+            .withMessage('email must be a string')
+            .bail()
+            .trim()
+            .notEmpty()
+            .withMessage('email is required')
+            .bail()
+            .isEmail()
+            .withMessage('email must be valid'),
+        body('phone')
+            .optional()
+            .isString()
+            .withMessage('phone must be a string'),
+        body('data')
+            .custom(value => {
+                return (
+                    value !== null &&
+                    typeof value === 'object' &&
+                    !Array.isArray(value) &&
+                    Object.keys(value).length > 0
+                )
+            })
+            .withMessage('data must be a non-empty object')
     ],
     validateRequest,
     contactForms.addRecord

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,7 +79,20 @@ app.use(
         res: express.Response,
         next: express.NextFunction
     ) => {
-        res.status(500).json({ message: err.message })
+        if (err?.type === 'entity.parse.failed') {
+            return res.status(400).json({ error: 'Invalid JSON body' })
+        }
+
+        const status =
+            typeof err?.status === 'number' && err.status >= 400
+                ? err.status
+                : 500
+        const message =
+            typeof err?.message === 'string' && err.message.length > 0
+                ? err.message
+                : 'Internal server error'
+
+        res.status(status).json({ error: message })
     }
 )
 

--- a/src/services/websites.ts
+++ b/src/services/websites.ts
@@ -18,18 +18,20 @@ const getWebsiteEmail = async (id: string) => {
 
 const getWebsiteDetailsForEmail = async (slug: string) => {
     try {
-        const {
-            data: { contact_email, title, id },
-            error
-        } = await db
+        const { data, error } = await db
             .from(Tables.WEBSITES)
-            .select()
+            .select('id, title, contact_email')
             .eq(COLUMNS.WEBSITE_SLUG, slug)
-            .single()
+            .maybeSingle()
 
         if (error) throw new Error(error.message)
+        if (!data) throw { status: 404, message: 'Website not found' }
 
-        return { contact_email, title, id }
+        return {
+            contact_email: data.contact_email,
+            title: data.title,
+            id: data.id
+        }
     } catch (error) {
         throw error
     }


### PR DESCRIPTION
## Summary
- return 400 for malformed JSON instead of generic 500s
- return 404 when a contact form website slug is not found
- keep persisted contact submissions successful even if notification email fails
- tighten contact form validation and error messages

## Testing
- npm run build
- curl malformed JSON against port 5002 -> 400 Invalid JSON body
- curl unknown slug against port 5002 -> 404 Website not found
- curl invalid contact form payload against port 5002 -> clear 400 validation errors

Note: did not send another successful Iffers submission during final verification because the test server was using staging mode and would notify the client contact email.