### PR TITLE
DEV-822: Add attribution storage sanitizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "server.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
+        "build": "tsc",
         "start": "ts-node src/server.ts",
         "serve": "nodemon src/server.ts"
     },

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -59,6 +59,7 @@ export const COLUMNS = {
     CONTACT_EMAIL: 'contact_email',
     WEBSITE_SLUG: 'website_slug',
     CALENDLY_EVENT_URI: 'calendly_event_uri',
+    ATTRIBUTION: 'attribution',
     PROSPECT_SOURCE: 'source',
     PROSPECT_STATUS: 'status',
 }

--- a/src/services/audit-requests.ts
+++ b/src/services/audit-requests.ts
@@ -1,4 +1,5 @@
 import { db, Tables } from '../lib/db'
+import { sanitizeAttribution, AttributionPayload } from '../utils/attribution'
 
 export interface AuditRequestPayload {
     name: string
@@ -9,6 +10,7 @@ export interface AuditRequestPayload {
     otherDetail?: string
     prospectId: string
     promoCode?: string
+    attribution?: unknown
 }
 
 export interface AuditRequestRecord {
@@ -22,6 +24,7 @@ export interface AuditRequestRecord {
     status: string
     prospect_id: string | null
     promo_code: string | null
+    attribution: AttributionPayload | null
     created_at: string
     updated_at: string
 }
@@ -35,6 +38,7 @@ const mapPayloadToRow = ({
     otherDetail,
     prospectId,
     promoCode,
+    attribution,
 }: AuditRequestPayload) => ({
     name,
     email,
@@ -44,6 +48,7 @@ const mapPayloadToRow = ({
     other_detail: otherDetail ?? null,
     prospect_id: prospectId,
     promo_code: promoCode ?? null,
+    attribution: sanitizeAttribution(attribution),
     status: 'pending',
 })
 

--- a/src/services/calendly-bookings.ts
+++ b/src/services/calendly-bookings.ts
@@ -1,4 +1,5 @@
 import { db, Tables, COLUMNS } from '../lib/db'
+import { sanitizeAttribution, AttributionPayload } from '../utils/attribution'
 
 export interface CalendlyBookingPayload {
     prospectId: string
@@ -9,6 +10,7 @@ export interface CalendlyBookingPayload {
     eventEndAt: string
     cancelUrl: string | null
     rescheduleUrl: string | null
+    attribution?: unknown
 }
 
 export interface CalendlyBookingRecord {
@@ -21,6 +23,7 @@ export interface CalendlyBookingRecord {
     event_end_at: string | null
     cancel_url: string | null
     reschedule_url: string | null
+    attribution: AttributionPayload | null
     canceled: boolean
     canceled_at: string | null
     created_at: string
@@ -53,6 +56,7 @@ export const createBooking = async (
             event_end_at: payload.eventEndAt,
             cancel_url: payload.cancelUrl,
             reschedule_url: payload.rescheduleUrl,
+            attribution: sanitizeAttribution(payload.attribution),
         })
         .select()
         .single()

--- a/src/services/lead-submissions.ts
+++ b/src/services/lead-submissions.ts
@@ -1,4 +1,5 @@
 import { db, Tables } from '../lib/db'
+import { sanitizeAttribution, AttributionPayload } from '../utils/attribution'
 
 export interface LeadSubmissionPayload {
     prospectId: string
@@ -11,6 +12,7 @@ export interface LeadSubmissionPayload {
     interestedIn?: string[]
     briefSummary?: string
     promoCode?: string
+    attribution?: unknown
 }
 
 export interface LeadSubmissionRecord {
@@ -25,6 +27,7 @@ export interface LeadSubmissionRecord {
     interested_in: string[] | null
     brief_summary: string | null
     promo_code: string | null
+    attribution: AttributionPayload | null
     created_at: string
 }
 
@@ -44,6 +47,7 @@ export const createLeadSubmission = async (
             interested_in: payload.interestedIn ?? null,
             brief_summary: payload.briefSummary || null,
             promo_code: payload.promoCode || null,
+            attribution: sanitizeAttribution(payload.attribution),
         })
         .select()
         .single()

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -1,0 +1,119 @@
+const TOUCH_FIELDS = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'utm_term',
+    'src_code',
+    'promo_code',
+    'landing_page',
+    'referrer',
+    'captured_at',
+] as const
+
+const CONVERSION_FIELDS = [
+    'conversion_page',
+    'conversion_type',
+    'converted_at',
+] as const
+
+type TouchField = (typeof TOUCH_FIELDS)[number]
+type ConversionField = (typeof CONVERSION_FIELDS)[number]
+
+export type AttributionTouch = Partial<Record<TouchField, string>>
+export type AttributionConversion = Partial<Record<ConversionField, string>>
+
+export interface AttributionPayload {
+    first_touch?: AttributionTouch | null
+    latest_touch?: AttributionTouch | null
+    conversion?: AttributionConversion | null
+}
+
+const FIELD_MAX_LENGTH: Record<TouchField | ConversionField, number> = {
+    utm_source: 128,
+    utm_medium: 128,
+    utm_campaign: 256,
+    utm_content: 256,
+    utm_term: 256,
+    src_code: 64,
+    promo_code: 64,
+    landing_page: 2048,
+    referrer: 2048,
+    captured_at: 64,
+    conversion_page: 2048,
+    conversion_type: 128,
+    converted_at: 64,
+}
+
+const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/
+const PHONE_QUERY_PARAM_PATTERN =
+    /(?:^|[?&#])(?:phone|tel|mobile|cell|sms)=[^&#]*\d/i
+const PHONE_STANDALONE_PATTERN =
+    /(?:^|[^\dT:-])\+?(?:\d[\s().-]?){10,15}(?=$|[^\d:-])/
+const IPV4_PATTERN =
+    /(?:^|[^\d])(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}(?=$|[^\d])/
+const BRACKETED_IPV6_PATTERN = /\[[a-f0-9:]*:[a-f0-9:]*:[a-f0-9:]*\]/i
+const COMPRESSED_IPV6_PATTERN = /(?:^|[^a-f0-9:])[a-f0-9:]*::[a-f0-9:]*(?=$|[^a-f0-9:])/i
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value)
+
+const sanitizeStringField = (
+    field: TouchField | ConversionField,
+    value: unknown
+): string | undefined => {
+    if (typeof value !== 'string') return undefined
+
+    const trimmed = value.trim()
+    if (!trimmed) return undefined
+    if (EMAIL_PATTERN.test(trimmed)) return undefined
+    if (
+        PHONE_QUERY_PARAM_PATTERN.test(trimmed) ||
+        PHONE_STANDALONE_PATTERN.test(trimmed)
+    ) {
+        return undefined
+    }
+    if (
+        IPV4_PATTERN.test(trimmed) ||
+        BRACKETED_IPV6_PATTERN.test(trimmed) ||
+        COMPRESSED_IPV6_PATTERN.test(trimmed)
+    ) {
+        return undefined
+    }
+
+    return trimmed.slice(0, FIELD_MAX_LENGTH[field])
+}
+
+const sanitizeSection = <Field extends TouchField | ConversionField>(
+    value: unknown,
+    allowedFields: readonly Field[]
+): Partial<Record<Field, string>> | undefined => {
+    if (!isPlainObject(value)) return undefined
+
+    const sanitized: Partial<Record<Field, string>> = {}
+    for (const field of allowedFields) {
+        const sanitizedValue = sanitizeStringField(field, value[field])
+        if (sanitizedValue) sanitized[field] = sanitizedValue
+    }
+
+    return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+export const sanitizeAttribution = (
+    value: unknown
+): AttributionPayload | null => {
+    if (!isPlainObject(value)) return null
+
+    const firstTouch = sanitizeSection(value.first_touch, TOUCH_FIELDS)
+    const latestTouch = sanitizeSection(value.latest_touch, TOUCH_FIELDS)
+    const conversion = sanitizeSection(value.conversion, CONVERSION_FIELDS)
+
+    const sanitized: AttributionPayload = {}
+    if (firstTouch) sanitized.first_touch = firstTouch
+    if (latestTouch) sanitized.latest_touch = latestTouch
+    if (conversion) sanitized.conversion = conversion
+
+    return Object.keys(sanitized).length > 0 ? sanitized : null
+}

--- a/supabase/migrations/20260509_add_attribution_to_conversion_records.sql
+++ b/supabase/migrations/20260509_add_attribution_to_conversion_records.sql
@@ -1,0 +1,93 @@
+-- ============================================================
+-- Migration: Add attribution metadata to conversion records
+-- DEV-822
+--
+-- Stores sanitized first-party attribution metadata on individual
+-- conversion rows. Nullable by design so existing and unattributed
+-- submissions continue to work unchanged.
+-- ============================================================
+
+ALTER TABLE public.lead_submissions
+    ADD COLUMN IF NOT EXISTS attribution jsonb DEFAULT NULL;
+
+ALTER TABLE public.audit_requests
+    ADD COLUMN IF NOT EXISTS attribution jsonb DEFAULT NULL;
+
+ALTER TABLE public.calendly_bookings
+    ADD COLUMN IF NOT EXISTS attribution jsonb DEFAULT NULL;
+
+-- ============================================================
+-- Refresh v_leads_detail to expose attribution
+-- ============================================================
+DROP VIEW IF EXISTS public.v_leads_detail;
+CREATE VIEW public.v_leads_detail AS
+SELECT
+    p.id AS prospect_id,
+    p.email,
+    p.name,
+    p.status,
+    p.created_at AS prospect_created_at,
+    ls.id AS submission_id,
+    ls.company_name,
+    ls.phone,
+    ls.budget,
+    ls.timeline,
+    ls.current_website,
+    ls.improvements,
+    ls.interested_in,
+    ls.brief_summary,
+    ls.promo_code,
+    ls.attribution,
+    ls.created_at AS submitted_at
+FROM public.prospects p
+JOIN public.lead_submissions ls ON ls.prospect_id = p.id
+ORDER BY ls.created_at DESC;
+
+-- ============================================================
+-- Refresh v_audits_detail to expose attribution
+-- ============================================================
+DROP VIEW IF EXISTS public.v_audits_detail;
+CREATE VIEW public.v_audits_detail AS
+SELECT
+    p.id AS prospect_id,
+    p.email,
+    p.name,
+    p.status,
+    p.created_at AS prospect_created_at,
+    ar.id AS audit_id,
+    ar.website_url,
+    ar.phone_number,
+    ar.specifics,
+    ar.acknowledged,
+    ar.status AS audit_status,
+    ar.promo_code,
+    ar.attribution,
+    ar.created_at AS submitted_at
+FROM public.prospects p
+JOIN public.audit_requests ar ON ar.prospect_id = p.id
+ORDER BY ar.created_at DESC;
+
+-- ============================================================
+-- Refresh v_calendly_detail to expose attribution
+-- ============================================================
+DROP VIEW IF EXISTS public.v_calendly_detail;
+CREATE VIEW public.v_calendly_detail AS
+SELECT
+    p.id AS prospect_id,
+    p.email,
+    p.name,
+    p.status,
+    p.created_at AS prospect_created_at,
+    cb.id AS booking_id,
+    cb.event_type_name,
+    cb.event_start_at,
+    cb.event_end_at,
+    cb.canceled,
+    cb.canceled_at,
+    cb.cancel_url,
+    cb.reschedule_url,
+    cb.attribution,
+    cb.created_at AS booked_at
+FROM public.prospects p
+JOIN public.calendly_bookings cb ON cb.prospect_id = p.id
+ORDER BY cb.event_start_at DESC;


### PR DESCRIPTION
## Summary
- add nullable attribution JSONB storage to lead submissions, audit requests, and Calendly bookings
- refresh prospect detail views to expose conversion attribution
- add a reusable attribution sanitizer that trims/caps allowed string fields, drops unknown keys, and rejects obvious email/phone values
- wire conversion services to sanitize optional attribution at insert time while preserving existing promo code behavior
- add the missing npm build script so the ticket acceptance check is runnable

## Testing
- npm run build
- node -r ts-node/register sanitizer smoke test for trimming, unknown-key dropping, empty-section dropping, email dropping, and timestamp preservation

## QA Checklist
- Submit a lead without attribution and confirm the lead still persists with attribution null
- Submit an audit request without attribution and confirm promo_code behavior is unchanged
- Apply the migration in staging and confirm v_leads_detail, v_audits_detail, and v_calendly_detail include attribution