### PR TITLE
DEV-823: Accept attribution on lead and audit submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 config.ts
 /repomix-output.txt
 .mcp.json
+.claude/
+dist/
+supabase/.temp/

--- a/src/controllers/audit.ts
+++ b/src/controllers/audit.ts
@@ -28,6 +28,7 @@ const auditSchema = z.object({
         .max(32)
         .optional()
         .transform(v => (v && v.length > 0 ? v : undefined)),
+    attribution: z.unknown().optional(),
     honeypot: z.string().optional(),
 })
 
@@ -114,6 +115,7 @@ const createAuditRequest = async (
             specifics,
             otherDetail,
             promoCode,
+            attribution,
         } = parsed
 
         const prospectId = await upsertProspect(email, name, 'review_request')
@@ -127,6 +129,7 @@ const createAuditRequest = async (
             otherDetail,
             prospectId,
             promoCode,
+            attribution,
         })
 
         sendAuditAlertToDiscord(record).catch((err) =>

--- a/src/controllers/leads.ts
+++ b/src/controllers/leads.ts
@@ -38,6 +38,7 @@ const leadsSchema = z.object({
         .max(32)
         .optional()
         .transform(v => (v && v.length > 0 ? v : undefined)),
+    attribution: z.unknown().optional(),
     honeypot: z.string().optional(),
 })
 
@@ -124,6 +125,7 @@ const createLead = async (req: Request, res: Response): Promise<Response> => {
             improvements,
             briefSummary,
             promoCode,
+            attribution,
         } = parsed
 
         const prospectId = await upsertProspect(email, name, 'details_form')
@@ -139,6 +141,7 @@ const createLead = async (req: Request, res: Response): Promise<Response> => {
             improvements,
             briefSummary,
             promoCode,
+            attribution,
         })
 
         sendLeadAlertToDiscord(parsed).catch((err) =>

--- a/src/services/audit-requests.ts
+++ b/src/services/audit-requests.ts
@@ -39,18 +39,22 @@ const mapPayloadToRow = ({
     prospectId,
     promoCode,
     attribution,
-}: AuditRequestPayload) => ({
-    name,
-    email,
-    website_url: websiteUrl,
-    phone_number: phoneNumber ?? null,
-    specifics: specifics ?? null,
-    other_detail: otherDetail ?? null,
-    prospect_id: prospectId,
-    promo_code: promoCode ?? null,
-    attribution: sanitizeAttribution(attribution),
-    status: 'pending',
-})
+}: AuditRequestPayload) => {
+    const sanitizedAttribution = sanitizeAttribution(attribution)
+
+    return {
+        name,
+        email,
+        website_url: websiteUrl,
+        phone_number: phoneNumber ?? null,
+        specifics: specifics ?? null,
+        other_detail: otherDetail ?? null,
+        prospect_id: prospectId,
+        promo_code: promoCode ?? null,
+        ...(sanitizedAttribution && { attribution: sanitizedAttribution }),
+        status: 'pending',
+    }
+}
 
 
 export const createAuditRequest = async (

--- a/src/services/calendly-bookings.ts
+++ b/src/services/calendly-bookings.ts
@@ -45,6 +45,8 @@ export const findBookingByEventUri = async (
 export const createBooking = async (
     payload: CalendlyBookingPayload
 ): Promise<CalendlyBookingRecord> => {
+    const attribution = sanitizeAttribution(payload.attribution)
+
     const { data, error } = await db
         .from(Tables.CALENDLY_BOOKINGS)
         .insert({
@@ -56,7 +58,7 @@ export const createBooking = async (
             event_end_at: payload.eventEndAt,
             cancel_url: payload.cancelUrl,
             reschedule_url: payload.rescheduleUrl,
-            attribution: sanitizeAttribution(payload.attribution),
+            ...(attribution && { attribution }),
         })
         .select()
         .single()

--- a/src/services/lead-submissions.ts
+++ b/src/services/lead-submissions.ts
@@ -34,6 +34,8 @@ export interface LeadSubmissionRecord {
 export const createLeadSubmission = async (
     payload: LeadSubmissionPayload
 ): Promise<LeadSubmissionRecord> => {
+    const attribution = sanitizeAttribution(payload.attribution)
+
     const { data, error } = await db
         .from(Tables.LEAD_SUBMISSIONS)
         .insert({
@@ -47,7 +49,7 @@ export const createLeadSubmission = async (
             interested_in: payload.interestedIn ?? null,
             brief_summary: payload.briefSummary || null,
             promo_code: payload.promoCode || null,
-            attribution: sanitizeAttribution(payload.attribution),
+            ...(attribution && { attribution }),
         })
         .select()
         .single()


### PR DESCRIPTION
## Summary
- accept optional attribution on POST /api/leads and POST /api/audit payloads
- pass attribution through controllers into the existing service-layer sanitizer/persistence path
- keep attribution out of Discord notification payloads
- omit attribution from conversion inserts when the sanitized value is empty, preserving valid unattributed submissions
- ignore local generated/tooling directories removed during cleanup

## Testing
- npm run build
- applied DEV-822 attribution migration to production Supabase
- verified attribution columns and reporting view projections exist for lead_submissions, audit_requests, calendly_bookings, v_leads_detail, v_audits_detail, and v_calendly_detail
- started API on port 5002 with notifications disabled
- curl POST /api/leads without attribution -> 201 Message received
- curl POST /api/audit without attribution -> 201 Audit request received
- curl POST /api/leads with attribution -> 201 Message received and sanitized attribution persisted
- curl POST /api/audit with attribution -> 201 Audit request received and sanitized attribution persisted
- verified unknown keys and disallowed phone/IP-bearing fields were dropped from stored attribution
- removed DEV-823 smoke-test records from Supabase after verification

## QA Checklist
- Submit a lead without attribution and confirm existing response/notification behavior
- Submit an audit request without attribution and confirm existing response/notification behavior
- Submit a lead with attribution containing unknown and disallowed keys and confirm only sanitized allowlisted fields persist
- Submit an audit request with attribution and confirm attribution is not included in Discord output