### PR TITLE
DEV-824: Accept Calendly attribution payloads

### DIFF
--- a/src/controllers/calendly-webhook.ts
+++ b/src/controllers/calendly-webhook.ts
@@ -10,6 +10,7 @@ import calendlyBookingsService from '../services/calendly-bookings'
 const calendlyBookingSchema = z.object({
     event_uri: z.string().url(),
     invitee_uri: z.string().url(),
+    attribution: z.unknown().optional(),
 })
 
 // ─── Calendly API client ──────────────────────────────────────────────────────
@@ -134,7 +135,9 @@ const sendBookingNotification = async (
 
 const handleWebhook = async (req: Request, res: Response): Promise<Response> => {
     try {
-        const { event_uri, invitee_uri } = calendlyBookingSchema.parse(req.body)
+        const { event_uri, invitee_uri, attribution } = calendlyBookingSchema.parse(
+            req.body
+        )
 
         // Idempotency: skip if already processed
         const existing = await calendlyBookingsService.findBookingByEventUri(event_uri)
@@ -172,6 +175,7 @@ const handleWebhook = async (req: Request, res: Response): Promise<Response> => 
             eventEndAt: end_time,
             cancelUrl: cancel_url,
             rescheduleUrl: reschedule_url,
+            attribution,
         })
 
         sendBookingNotification(name, email, eventTypeName, start_time, cancel_url).catch(

--- a/src/services/calendly-bookings.ts
+++ b/src/services/calendly-bookings.ts
@@ -1,5 +1,10 @@
 import { db, Tables, COLUMNS } from '../lib/db'
-import { sanitizeAttribution, AttributionPayload } from '../utils/attribution'
+import {
+    sanitizeAttribution,
+    AttributionPayload,
+    AttributionTouch,
+    AttributionConversion,
+} from '../utils/attribution'
 
 export interface CalendlyBookingPayload {
     prospectId: string
@@ -29,6 +34,55 @@ export interface CalendlyBookingRecord {
     created_at: string
 }
 
+const CALENDLY_ACTION_URL_PATTERN =
+    /https:\/\/calendly\.com\/(?:cancellations|reschedulings)\//i
+const ENCODED_CALENDLY_ACTION_URL_PATTERN =
+    /https?%3A%2F%2Fcalendly\.com%2F(?:cancellations|reschedulings)%2F/i
+
+const includesCalendlyActionUrl = (value: string): boolean => {
+    const trimmed = value.trim()
+    return (
+        CALENDLY_ACTION_URL_PATTERN.test(trimmed) ||
+        ENCODED_CALENDLY_ACTION_URL_PATTERN.test(trimmed)
+    )
+}
+
+const omitCalendlyActionUrlsFromSection = <
+    Section extends AttributionTouch | AttributionConversion,
+>(
+    section: Section | null | undefined
+): Section | undefined => {
+    if (!section) return undefined
+
+    const filtered = Object.fromEntries(
+        Object.entries(section).filter(([, value]) => {
+            return (
+                typeof value === 'string' &&
+                !includesCalendlyActionUrl(value)
+            )
+        })
+    ) as Section
+
+    return Object.keys(filtered).length > 0 ? filtered : undefined
+}
+
+const omitCalendlyActionUrlsFromAttribution = (
+    attribution: AttributionPayload | null
+): AttributionPayload | null => {
+    if (!attribution) return null
+
+    const firstTouch = omitCalendlyActionUrlsFromSection(attribution.first_touch)
+    const latestTouch = omitCalendlyActionUrlsFromSection(attribution.latest_touch)
+    const conversion = omitCalendlyActionUrlsFromSection(attribution.conversion)
+
+    const filtered: AttributionPayload = {}
+    if (firstTouch) filtered.first_touch = firstTouch
+    if (latestTouch) filtered.latest_touch = latestTouch
+    if (conversion) filtered.conversion = conversion
+
+    return Object.keys(filtered).length > 0 ? filtered : null
+}
+
 export const findBookingByEventUri = async (
     eventUri: string
 ): Promise<CalendlyBookingRecord | null> => {
@@ -45,7 +99,9 @@ export const findBookingByEventUri = async (
 export const createBooking = async (
     payload: CalendlyBookingPayload
 ): Promise<CalendlyBookingRecord> => {
-    const attribution = sanitizeAttribution(payload.attribution)
+    const attribution = omitCalendlyActionUrlsFromAttribution(
+        sanitizeAttribution(payload.attribution)
+    )
 
     const { data, error } = await db
         .from(Tables.CALENDLY_BOOKINGS)


### PR DESCRIPTION
## Summary
- accept optional attribution on Calendly webhook payloads
- pass attribution into Calendly booking creation for sanitizer-backed persistence
- strip Calendly cancel/reschedule URLs from booking attribution before insert

## Verification
- npm run build
- direct controller stub check for payloads with and without attribution
- direct service insert stub check that Calendly cancellation/reschedule URLs are omitted from stored attribution

## QA
- POST /api/webhooks/calendly with the existing event_uri/invitee_uri body and confirm it still records or idempotently accepts the booking
- POST /api/webhooks/calendly with attribution and confirm sanitized attribution is present on the new calendly_bookings row
- Repost the same event_uri and confirm the response remains idempotent and existing attribution is not changed