### PR TITLE
DEV-825: Expose attribution in prospect reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
     - Lead submissions use the Resend API (`src/controllers/leads.ts`) to notify the ops team. Configure `RESEND_API_KEY`, `LEAD_NOTIFY_TO`, and optionally `LEAD_NOTIFY_FROM`.
 -   **Lead Intake Flow**
     - `/api/leads` intentionally bypasses shared services and calls Supabase REST + Resend directly from the controller for clarity. Keep that file in sync if you expand lead handling.
+-   **Prospect Attribution Reporting**
+    - Campaign attribution is internal-only. Inspect full sanitized JSON on nested conversion rows returned by `GET /api/prospects/:id` and in `v_leads_detail`, `v_audits_detail`, and `v_calendly_detail`.
+    - `v_prospects_all` exposes only lightweight latest-attribution scalar fields for list/reporting views: source, medium, campaign, and conversion type.
 -   **Legacy Nodemailer Utilities**
     -   Files in `src/utils/mailer/**` and `src/utils/token.js` are CommonJS modules dating back to the Mongo implementation. Confirm usage before refactoring; some may be dead code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1164,6 +1164,13 @@ if (existingLead) {
    - Check email delivery
    - Test error cases
 
+### Internal Prospect Attribution Reporting
+
+- Campaign attribution is internal-only and should not be added to public submission responses.
+- `GET /api/prospects/:id` returns full sanitized attribution JSON on nested `lead_submissions`, `audit_requests`, and `calendly_bookings` rows when present.
+- Reporting views `v_leads_detail`, `v_audits_detail`, and `v_calendly_detail` expose full attribution JSON for conversion-level analysis.
+- List/reporting view `v_prospects_all` intentionally exposes only lightweight latest-attribution scalar fields: source, medium, campaign, and conversion type.
+
 ### Example: Adding a New Resource
 
 ```typescript

--- a/supabase/migrations/20260510_expose_attribution_in_prospect_reporting.sql
+++ b/supabase/migrations/20260510_expose_attribution_in_prospect_reporting.sql
@@ -1,0 +1,150 @@
+-- ============================================================
+-- Migration: Expose attribution in internal prospect reporting
+-- DEV-825
+--
+-- Keeps full attribution JSON on conversion detail views and
+-- adds small latest-attribution fields to the prospect list view.
+-- ============================================================
+
+-- ============================================================
+-- Refresh v_prospects_all with lightweight latest attribution
+-- ============================================================
+CREATE OR REPLACE VIEW public.v_prospects_all AS
+SELECT
+    p.id,
+    p.email,
+    p.name,
+    p.source,
+    p.status,
+    p.notes,
+    p.created_at,
+    p.updated_at,
+    COALESCE(ls.cnt,  0) AS lead_submission_count,
+    COALESCE(ar.cnt,  0) AS audit_request_count,
+    COALESCE(cb.cnt,  0) AS calendly_booking_count,
+    COALESCE(
+        latest_attribution.attribution #>> '{latest_touch,utm_source}',
+        latest_attribution.attribution #>> '{first_touch,utm_source}'
+    ) AS latest_attribution_source,
+    COALESCE(
+        latest_attribution.attribution #>> '{latest_touch,utm_medium}',
+        latest_attribution.attribution #>> '{first_touch,utm_medium}'
+    ) AS latest_attribution_medium,
+    COALESCE(
+        latest_attribution.attribution #>> '{latest_touch,utm_campaign}',
+        latest_attribution.attribution #>> '{first_touch,utm_campaign}'
+    ) AS latest_attribution_campaign,
+    latest_attribution.attribution #>> '{conversion,conversion_type}' AS latest_attribution_conversion_type
+FROM public.prospects p
+LEFT JOIN (
+    SELECT prospect_id, COUNT(*) AS cnt
+    FROM public.lead_submissions
+    GROUP BY prospect_id
+) ls ON ls.prospect_id = p.id
+LEFT JOIN (
+    SELECT prospect_id, COUNT(*) AS cnt
+    FROM public.audit_requests
+    WHERE prospect_id IS NOT NULL
+    GROUP BY prospect_id
+) ar ON ar.prospect_id = p.id
+LEFT JOIN (
+    SELECT prospect_id, COUNT(*) AS cnt
+    FROM public.calendly_bookings
+    GROUP BY prospect_id
+) cb ON cb.prospect_id = p.id
+LEFT JOIN LATERAL (
+    SELECT attribution
+    FROM (
+        SELECT attribution, created_at
+        FROM public.lead_submissions
+        WHERE prospect_id = p.id AND attribution IS NOT NULL
+
+        UNION ALL
+
+        SELECT attribution, created_at
+        FROM public.audit_requests
+        WHERE prospect_id = p.id AND attribution IS NOT NULL
+
+        UNION ALL
+
+        SELECT attribution, created_at
+        FROM public.calendly_bookings
+        WHERE prospect_id = p.id AND attribution IS NOT NULL
+    ) attributed_conversions
+    ORDER BY created_at DESC
+    LIMIT 1
+) latest_attribution ON true
+ORDER BY p.created_at DESC;
+
+-- ============================================================
+-- Refresh v_leads_detail to expose attribution
+-- ============================================================
+CREATE OR REPLACE VIEW public.v_leads_detail AS
+SELECT
+    p.id AS prospect_id,
+    p.email,
+    p.name,
+    p.status,
+    p.created_at AS prospect_created_at,
+    ls.id AS submission_id,
+    ls.company_name,
+    ls.phone,
+    ls.budget,
+    ls.timeline,
+    ls.current_website,
+    ls.improvements,
+    ls.interested_in,
+    ls.brief_summary,
+    ls.promo_code,
+    ls.attribution,
+    ls.created_at AS submitted_at
+FROM public.prospects p
+JOIN public.lead_submissions ls ON ls.prospect_id = p.id
+ORDER BY ls.created_at DESC;
+
+-- ============================================================
+-- Refresh v_audits_detail to expose attribution
+-- ============================================================
+CREATE OR REPLACE VIEW public.v_audits_detail AS
+SELECT
+    p.id AS prospect_id,
+    p.email,
+    p.name,
+    p.status,
+    p.created_at AS prospect_created_at,
+    ar.id AS audit_id,
+    ar.website_url,
+    ar.phone_number,
+    ar.specifics,
+    ar.acknowledged,
+    ar.status AS audit_status,
+    ar.promo_code,
+    ar.attribution,
+    ar.created_at AS submitted_at
+FROM public.prospects p
+JOIN public.audit_requests ar ON ar.prospect_id = p.id
+ORDER BY ar.created_at DESC;
+
+-- ============================================================
+-- Refresh v_calendly_detail to expose attribution
+-- ============================================================
+CREATE OR REPLACE VIEW public.v_calendly_detail AS
+SELECT
+    p.id AS prospect_id,
+    p.email,
+    p.name,
+    p.status,
+    p.created_at AS prospect_created_at,
+    cb.id AS booking_id,
+    cb.event_type_name,
+    cb.event_start_at,
+    cb.event_end_at,
+    cb.canceled,
+    cb.canceled_at,
+    cb.cancel_url,
+    cb.reschedule_url,
+    cb.attribution,
+    cb.created_at AS booked_at
+FROM public.prospects p
+JOIN public.calendly_bookings cb ON cb.prospect_id = p.id
+ORDER BY cb.event_start_at DESC;


### PR DESCRIPTION
## Summary
- add a forward migration that refreshes prospect reporting views with attribution exposure
- keep full attribution JSON on lead, audit, and Calendly detail views
- add lightweight latest-attribution scalar fields to v_prospects_all for list/reporting use
- document where internal campaign attribution can be inspected

## Verification
- npm run build
- read-only Supabase check confirmed existing prospect detail returns attribution properties on nested lead and audit rows
- read-only Supabase check found no current calendly_bookings rows to verify live Calendly detail data without creating fixtures

## Notes
- This does not expose attribution on public conversion success responses.
- The migration depends on DEV-822 attribution columns already existing.

## QA
- Apply the migration and query v_leads_detail, v_audits_detail, and v_calendly_detail to confirm attribution is selectable
- Query v_prospects_all and confirm latest_attribution_source, latest_attribution_medium, latest_attribution_campaign, and latest_attribution_conversion_type are present and nullable
- Fetch GET /api/prospects/:id for prospects with lead, audit, and Calendly conversions and confirm nested conversion rows include attribution when present