### PR TITLE
DEV-892 Migrate intake alerts to Slack

### DIFF
--- a/src/controllers/audit.ts
+++ b/src/controllers/audit.ts
@@ -4,6 +4,7 @@ import { z, ZodError } from 'zod'
 import { handleGenericError } from '../utils/http'
 import { upsertProspect } from '../services/prospects'
 import auditRequestsService, { AuditRequestRecord } from '../services/audit-requests'
+import { sendSlackNotification } from '../lib/slack-notifier'
 
 const auditSchema = z.object({
     name: z.string().min(1).max(200),
@@ -32,67 +33,28 @@ const auditSchema = z.object({
     honeypot: z.string().optional(),
 })
 
-const DISCORD_USERNAME = 'PixelVerse Audit Alerts'
-const DISCORD_TITLE = '📝 Website Review Request'
-
-const resolveWebhookUrl = (): string => {
-    const webhookUrl = process.env.LEAD_NOTIFY_DISCORD_WEBHOOK?.trim()
-    if (!webhookUrl) throw new Error('LEAD_NOTIFY_DISCORD_WEBHOOK is not configured')
-    return webhookUrl
-}
-
-const buildDiscordDescription = (record: AuditRequestRecord): string => {
-    const lines = [
-        '────────────────────────',
-        `👤 Name:        ${record.name}`,
-        `📧 Email:       ${record.email}`,
-        `🌐 Website:     ${record.website_url}`,
-        `📞 Phone:       ${record.phone_number ?? 'Not provided'}`,
-        `🔍 Focus areas: ${record.specifics ?? 'Not specified'}`,
-    ]
-
-    if (record.other_detail) {
-        lines.push(`📝 Other:       ${record.other_detail}`)
-    }
-
-    if (record.promo_code) {
-        lines.push(`🎟 Promo:       ${record.promo_code}`)
-    }
-
-    return lines.join('\n')
-}
-
-const sendAuditAlertToDiscord = async (
+const sendAuditAlertToSlack = async (
     record: AuditRequestRecord
 ): Promise<void> => {
-    const webhookUrl = resolveWebhookUrl()
-    const description = buildDiscordDescription(record)
-
-    if (description.length > 4096) {
-        throw new Error('Discord payload exceeds maximum embed length')
-    }
-
-    const response = await fetch(webhookUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            username: DISCORD_USERNAME,
-            content: DISCORD_TITLE,
-            embeds: [
-                {
-                    description,
-                    color: 0x3f00e9,
-                    timestamp: record.created_at,
-                    footer: { text: 'Audit request notifications' },
-                },
-            ],
-        }),
+    await sendSlackNotification({
+        title: 'New Website Audit Request',
+        category: 'Website Audit',
+        description: 'A prospective client requested a free website audit.',
+        timestamp: record.created_at,
+        fields: [
+            { label: 'Name', value: record.name },
+            { label: 'Email', value: record.email },
+            { label: 'Website', value: record.website_url },
+            { label: 'Phone', value: record.phone_number },
+            { label: 'Focus Areas', value: record.specifics },
+            ...(record.other_detail
+                ? [{ label: 'Other Details', value: record.other_detail }]
+                : []),
+            ...(record.promo_code
+                ? [{ label: 'Promo', value: record.promo_code }]
+                : []),
+        ],
     })
-
-    if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Discord webhook failed (${response.status}): ${errorText}`)
-    }
 }
 
 const createAuditRequest = async (
@@ -132,8 +94,8 @@ const createAuditRequest = async (
             attribution,
         })
 
-        sendAuditAlertToDiscord(record).catch((err) =>
-            console.error('Discord notification failed (audit saved):', err)
+        sendAuditAlertToSlack(record).catch((err) =>
+            console.error('Slack notification failed (audit saved):', err)
         )
 
         return res.status(201).json({ message: 'Audit request received.' })

--- a/src/controllers/calendly-webhook.ts
+++ b/src/controllers/calendly-webhook.ts
@@ -4,6 +4,7 @@ import { z, ZodError } from 'zod'
 import { handleGenericError } from '../utils/http'
 import { upsertProspect } from '../services/prospects'
 import calendlyBookingsService from '../services/calendly-bookings'
+import { sendSlackNotification } from '../lib/slack-notifier'
 
 // ─── Zod schema ──────────────────────────────────────────────────────────────
 
@@ -66,16 +67,7 @@ const calendlyFetch = async <T>(path: string): Promise<T> => {
     return response.json() as Promise<T>
 }
 
-// ─── Discord notifications ────────────────────────────────────────────────────
-
-const DISCORD_USERNAME = 'PixelVerse Calendly Alerts'
-const DISCORD_COLOR = 0x3f00e9
-
-const resolveWebhookUrl = (): string => {
-    const url = process.env.LEAD_NOTIFY_DISCORD_WEBHOOK?.trim()
-    if (!url) throw new Error('LEAD_NOTIFY_DISCORD_WEBHOOK is not configured')
-    return url
-}
+// ─── Slack notifications ──────────────────────────────────────────────────────
 
 const formatEventTime = (isoString: string): string => {
     const date = new Date(isoString)
@@ -98,37 +90,18 @@ const sendBookingNotification = async (
     eventStartAt: string,
     cancelUrl: string | null
 ): Promise<void> => {
-    const webhookUrl = resolveWebhookUrl()
-    const description = [
-        '────────────────────────',
-        `👤 Name:      ${name}`,
-        `📧 Email:     ${email}`,
-        `🗓 Event:     ${eventTypeName}`,
-        `📆 Scheduled: ${formatEventTime(eventStartAt)}`,
-        `🔗 Cancel:    ${cancelUrl ?? 'N/A'}`,
-    ].join('\n')
-
-    const response = await fetch(webhookUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            username: DISCORD_USERNAME,
-            content: '📅 Calendly Call Booked',
-            embeds: [
-                {
-                    description,
-                    color: DISCORD_COLOR,
-                    timestamp: new Date().toISOString(),
-                    footer: { text: 'Calendly booking notifications' },
-                },
-            ],
-        }),
+    await sendSlackNotification({
+        title: 'New Calendly Booking',
+        category: 'Calendar',
+        description: 'A prospective client booked a Calendly call.',
+        fields: [
+            { label: 'Name', value: name },
+            { label: 'Email', value: email },
+            { label: 'Event', value: eventTypeName },
+            { label: 'Scheduled', value: formatEventTime(eventStartAt) },
+            ...(cancelUrl ? [{ label: 'Cancel Link', value: cancelUrl }] : []),
+        ],
     })
-
-    if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Discord webhook failed (${response.status}): ${errorText}`)
-    }
 }
 
 // ─── Controller ───────────────────────────────────────────────────────────────
@@ -179,7 +152,7 @@ const handleWebhook = async (req: Request, res: Response): Promise<Response> => 
         })
 
         sendBookingNotification(name, email, eventTypeName, start_time, cancel_url).catch(
-            (err) => console.error('Discord notification failed (booking saved):', err)
+            (err) => console.error('Slack notification failed (booking saved):', err)
         )
 
         console.log('Calendly booking created', { email, event_uri })

--- a/src/controllers/leads.ts
+++ b/src/controllers/leads.ts
@@ -4,6 +4,7 @@ import { z, ZodError } from 'zod'
 import { handleGenericError } from '../utils/http'
 import { upsertProspect } from '../services/prospects'
 import leadSubmissionsService from '../services/lead-submissions'
+import { sendSlackNotification } from '../lib/slack-notifier'
 
 const leadsSchema = z.object({
     name: z.string().min(2).max(100),
@@ -42,66 +43,27 @@ const leadsSchema = z.object({
     honeypot: z.string().optional(),
 })
 
-const DISCORD_USERNAME = 'PixelVerse Lead Alerts'
-const DISCORD_TITLE = '📋 New Lead — Details Form'
-
-const resolveWebhookUrl = (): string => {
-    const webhookUrl = process.env.LEAD_NOTIFY_DISCORD_WEBHOOK?.trim()
-    if (!webhookUrl) throw new Error('LEAD_NOTIFY_DISCORD_WEBHOOK is not configured')
-    return webhookUrl
-}
-
-const buildDiscordDescription = (data: z.infer<typeof leadsSchema>): string => {
-    const lines = [
-        '──────────────────────────',
-        `👤 Name:      ${data.name}`,
-        `📧 Email:     ${data.email}`,
-        `🏢 Company:   ${data.companyName}`,
-        `📞 Phone:     ${data.phone || 'Not provided'}`,
-        `💰 Budget:    ${data.budget}`,
-        `⏱ Timeline:  ${data.timeline}`,
-        `🌐 Website:   ${data.currentWebsite || 'Not provided'}`,
-        `🎯 Services:  ${data.interestedIn?.join(', ') || 'Not specified'}`,
-        `🔧 Needs:     ${data.improvements.join(', ')}`,
-        `📝 Notes:     ${data.briefSummary || 'None'}`,
-    ]
-    if (data.promoCode) {
-        lines.push(`🎟 Promo:     ${data.promoCode}`)
-    }
-    return lines.join('\n')
-}
-
-const sendLeadAlertToDiscord = async (
+const sendLeadAlertToSlack = async (
     data: z.infer<typeof leadsSchema>
 ): Promise<void> => {
-    const webhookUrl = resolveWebhookUrl()
-    const description = buildDiscordDescription(data)
-
-    if (description.length > 4096) {
-        throw new Error('Discord payload exceeds maximum embed length')
-    }
-
-    const response = await fetch(webhookUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            username: DISCORD_USERNAME,
-            content: DISCORD_TITLE,
-            embeds: [
-                {
-                    description,
-                    color: 0x3f00e9,
-                    timestamp: new Date().toISOString(),
-                    footer: { text: 'Lead intake notifications' },
-                },
-            ],
-        }),
+    await sendSlackNotification({
+        title: 'New Lead Submission',
+        category: 'Details Form',
+        description: 'A prospective client submitted the project details form.',
+        fields: [
+            { label: 'Name', value: data.name },
+            { label: 'Email', value: data.email },
+            { label: 'Company', value: data.companyName },
+            { label: 'Phone', value: data.phone },
+            { label: 'Budget', value: data.budget },
+            { label: 'Timeline', value: data.timeline },
+            { label: 'Website', value: data.currentWebsite },
+            { label: 'Services', value: data.interestedIn?.join(', ') },
+            { label: 'Needs', value: data.improvements.join(', ') },
+            { label: 'Notes', value: data.briefSummary || 'None' },
+            ...(data.promoCode ? [{ label: 'Promo', value: data.promoCode }] : []),
+        ],
     })
-
-    if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Discord webhook failed (${response.status}): ${errorText}`)
-    }
 }
 
 const createLead = async (req: Request, res: Response): Promise<Response> => {
@@ -144,8 +106,8 @@ const createLead = async (req: Request, res: Response): Promise<Response> => {
             attribution,
         })
 
-        sendLeadAlertToDiscord(parsed).catch((err) =>
-            console.error('Discord notification failed (lead saved):', err)
+        sendLeadAlertToSlack(parsed).catch((err) =>
+            console.error('Slack notification failed (lead saved):', err)
         )
 
         console.log('Lead submission created', { email })


### PR DESCRIPTION
## Summary
- Replace lead, audit request, and Calendly booking Discord webhook calls with the shared Slack notifier
- Preserve post-persistence, non-blocking notification behavior
- Keep Slack alert fields customer-facing and omit internal IDs/attribution metadata

## QA
- [x] npm run build
- [x] Confirm touched controllers no longer reference Discord webhook helpers or env vars
- [ ] Configure OPS_NOTIFY_SLACK_WEBHOOK in a test environment
- [ ] Submit /api/leads and verify persistence plus Slack alert
- [ ] Submit /api/audit-requests and verify persistence plus Slack alert
- [ ] Trigger /api/webhooks/calendly and verify persistence plus Slack alert
- [ ] Confirm invalid/missing Slack webhook logs an error without changing successful API responses after persistence

## Notes
- Live Slack posting is deferred to environment QA because this branch does not include secrets.
- AGENTS.md/env documentation cleanup remains scoped to DEV-894.