### PR TITLE
DEV-893 Remove Discord notification env usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,6 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `RESEND_API_KEY` | Resend API token for lead notifications. |
 | `LEAD_NOTIFY_TO` | Comma-separated recipient list for lead notifications (defaults to ops@pixelversestudios.io). |
 | `LEAD_NOTIFY_FROM` | Optional override for the Resend “from” address. |
-| `LEAD_NOTIFY_USE_RESEND` | Toggle Resend lead notifications (`false` to route alerts to Discord). |
-| `LEAD_NOTIFY_DISCORD_WEBHOOK` | Discord webhook endpoint used for lead and audit alerts when Resend is disabled. |
 
 Store secrets outside version control. For Supabase service keys, restrict to necessary tables.
 


### PR DESCRIPTION
## Summary
- Remove remaining active Discord notification env references from AGENTS.md
- Leave legacy docs outside active instructions untouched per ticket scope
- Leave unrelated Resend email campaign implementation untouched

## QA
- [x] npm run build
- [x] rg "Discord|discord|DISCORD|LEAD_NOTIFY_DISCORD|LEAD_NOTIFY_USE_RESEND" src AGENTS.md returns no matches

## Notes
- TypeScript source already had Discord notification helpers removed by DEV-892.
- Broader Slack notification documentation cleanup remains scoped to DEV-894.