### PR TITLE
DEV-907 Add API CI checks

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,0 +1,35 @@
+name: API CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev/**
+      - dev-*
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary
- Add a GitHub Actions PR workflow for API CI
- Run npm ci, npm run build, and npm test
- Trigger on PRs targeting main, dev/**, and dev-* branches without requiring secrets

## Verification
- npm ci
- npm test
- npm run build
- git diff --check

## QA Checklist
- Open this PR and confirm the API CI workflow appears as a status check
- Confirm the workflow installs with npm ci
- Confirm the workflow runs build and test without Slack, Supabase, Gmail, Resend, or Calendly secrets