### PR TITLE
DEV-935 Add media admin magic-link auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,17 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `/api/v1/contact-forms` | GET | Retrieve all submissions. | `controllers/contact-forms.getAll` |
 | `/api/v1/contact-forms/:website_slug` | POST | Create submission and trigger email. | `controllers/contact-forms.addRecord` |
 | `/api/audit` | POST | Capture Free Website Audit submissions, persist to Supabase, and notify ops. | `controllers/audit.createAuditRequest` |
+| `/api/media-admin/auth/magic-link` | POST | Request a media admin magic link for approved emails without revealing approval status. | `controllers/media-admin-auth.requestMagicLink` |
+| `/api/media-admin/auth/callback` | POST | Exchange a one-time magic-link token for an HTTP-only media admin session cookie. | `controllers/media-admin-auth.callback` |
+| `/api/media-admin/auth/session` | GET | Return the current media admin session when the session cookie is valid. | `controllers/media-admin-auth.getSession` |
+| `/api/media-admin/auth/logout` | POST | Revoke the current media admin session and clear the cookie. | `controllers/media-admin-auth.logout` |
 
 > `routes/recaptcha.ts` is currently a placeholder; wire it before exposing any verification endpoint.
 
 ## Data + External Services
 
 -   **Supabase**
-    -   Tables in use: `clients`, `cms`, `newsletter`, `contact_form_submissions`, `websites`, `leads`, `audit_requests`, `media_r2_configs`, `media_catalog_items`, `media_audit_logs`.
+    -   Tables in use: `clients`, `cms`, `newsletter`, `contact_form_submissions`, `websites`, `leads`, `audit_requests`, `media_r2_configs`, `media_catalog_items`, `media_audit_logs`, `media_admin_magic_links`, `media_admin_sessions`.
     -   Always import `Tables` and `COLUMNS` from `src/lib/db.ts` to avoid string literals.
     -   Use `db.from(...).select()` and `.eq(...)` rather than raw SQL. Controllers typically `await` and throw Supabase errors so `handleGenericError` can respond with `500`.
 -   **Email (Gmail OAuth2)**
@@ -101,6 +105,7 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `GMAIL_CLIENT_ID` | Google OAuth client id. |
 | `GMAIL_CLIENT_SECRET` | Google OAuth client secret. |
 | `GMAIL_REFRESH_TOKEN` | Refresh token for Gmail OAuth workflow. |
+| `GMAIL_APP_PASSWORD` | Gmail app password used by the current Nodemailer transporter. |
 | `NODE_ENVIRONMENT` | Controls dev-mode email fallback (set to `development` locally). |
 | `TOKEN_SECRET` | Shared secret for JWT helpers in `src/utils/token.js` (legacy). |
 | `TOKEN_EXPIRE` | Lifetime for generated JWTs (legacy, defaults to `24hr`). |
@@ -112,6 +117,10 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `R2_ACCOUNT_ID` | Cloudflare account id for future R2 S3-compatible API calls. |
 | `R2_BUCKET_NAME` | Fallback Cloudflare R2 bucket name for media manager features when no per-client config exists. |
 | `R2_PUBLIC_BASE_URL` | Fallback public base URL for R2 media objects when no per-client config exists. |
+| `MEDIA_ADMIN_EMAILS` | Comma-separated approved media manager admin email addresses. |
+| `MEDIA_ADMIN_APP_BASE_URL` | Frontend base URL used when generating media admin magic links. |
+| `MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES` | Optional magic-link expiry window; defaults to 15 minutes. |
+| `MEDIA_ADMIN_SESSION_TTL_HOURS` | Optional media admin session duration; defaults to 12 hours. |
 
 Store secrets outside version control. For Supabase service keys, restrict to necessary tables.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `MEDIA_ADMIN_APP_BASE_URL` | Frontend base URL used when generating media admin magic links. |
 | `MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES` | Optional magic-link expiry window; defaults to 15 minutes. |
 | `MEDIA_ADMIN_SESSION_TTL_HOURS` | Optional media admin session duration; defaults to 12 hours. |
+| `MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS` | Optional minimum response time for media admin magic-link requests; defaults to 350ms to reduce email approval probing. |
 
 Store secrets outside version control. For Supabase service keys, restrict to necessary tables.
 

--- a/docs/media-admin-auth.md
+++ b/docs/media-admin-auth.md
@@ -12,6 +12,7 @@ admin mutations with `requireMediaAdminSession`.
 | `MEDIA_ADMIN_APP_BASE_URL` | yes | Frontend base URL used in magic-link emails. |
 | `MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES` | no | Magic-link expiry window. Defaults to `15`. |
 | `MEDIA_ADMIN_SESSION_TTL_HOURS` | no | Session cookie lifetime. Defaults to `12`. |
+| `MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS` | no | Minimum magic-link request duration to reduce email approval probing. Defaults to `350`. |
 | `GMAIL_USER` | yes | Sender account for Nodemailer. |
 | `GMAIL_APP_PASSWORD` | yes | Gmail app password for Nodemailer. |
 
@@ -28,7 +29,8 @@ admin mutations with `requireMediaAdminSession`.
 ```
 
 Returns `200` for approved and unapproved emails so approval status is not
-leaked through the response.
+leaked through the response. Persistence or email-send failures are logged
+server-side and still return the same generic response.
 
 ```json
 {
@@ -69,7 +71,7 @@ Important failure states:
 | `401` | Invalid sign-in link. |
 | `403` | Email is no longer approved. |
 | `410` | Link expired or was already used. |
-| `500` | Email send or persistence failure. |
+| `500` | Unexpected callback/session persistence failure. |
 
 ### Current Session
 
@@ -89,8 +91,9 @@ expired and `403` when the session email is no longer approved.
 
 `POST /api/media-admin/auth/logout`
 
-Requires the session cookie. Revokes the stored session hash and clears the
-browser cookie.
+Revokes the stored session hash when a session cookie is present and always
+clears the browser cookie, including already-expired or already-revoked
+sessions.
 
 ```json
 {

--- a/docs/media-admin-auth.md
+++ b/docs/media-admin-auth.md
@@ -1,0 +1,106 @@
+# Media Admin Auth Contract
+
+DEV-935 adds lightweight magic-link auth for the Iffer's Pictures media manager.
+Permanent R2 credentials stay server-side; future media endpoints should protect
+admin mutations with `requireMediaAdminSession`.
+
+## Environment
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `MEDIA_ADMIN_EMAILS` | yes | Comma-separated approved admin email addresses. |
+| `MEDIA_ADMIN_APP_BASE_URL` | yes | Frontend base URL used in magic-link emails. |
+| `MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES` | no | Magic-link expiry window. Defaults to `15`. |
+| `MEDIA_ADMIN_SESSION_TTL_HOURS` | no | Session cookie lifetime. Defaults to `12`. |
+| `GMAIL_USER` | yes | Sender account for Nodemailer. |
+| `GMAIL_APP_PASSWORD` | yes | Gmail app password for Nodemailer. |
+
+## Routes
+
+### Request Magic Link
+
+`POST /api/media-admin/auth/magic-link`
+
+```json
+{
+  "email": "jenn@example.com"
+}
+```
+
+Returns `200` for approved and unapproved emails so approval status is not
+leaked through the response.
+
+```json
+{
+  "message": "If that email is approved, a sign-in link has been sent."
+}
+```
+
+### Complete Sign-In
+
+The emailed URL points to:
+
+`{MEDIA_ADMIN_APP_BASE_URL}/admin/media/auth/callback?token=...`
+
+The Next.js callback page should read the `token` query param and exchange it:
+
+`POST /api/media-admin/auth/callback`
+
+```json
+{
+  "token": "one-time-token-from-email"
+}
+```
+
+On success, the API sets the HTTP-only `pvs_media_admin_session` cookie.
+
+```json
+{
+  "email": "jenn@example.com",
+  "expiresAt": "2026-05-27T12:00:00.000Z"
+}
+```
+
+Important failure states:
+
+| Status | Meaning |
+| --- | --- |
+| `400` | Invalid payload. |
+| `401` | Invalid sign-in link. |
+| `403` | Email is no longer approved. |
+| `410` | Link expired or was already used. |
+| `500` | Email send or persistence failure. |
+
+### Current Session
+
+`GET /api/media-admin/auth/session`
+
+Requires the `pvs_media_admin_session` cookie. Returns `401` when missing or
+expired and `403` when the session email is no longer approved.
+
+```json
+{
+  "email": "jenn@example.com",
+  "expiresAt": "2026-05-27T12:00:00.000Z"
+}
+```
+
+### Logout
+
+`POST /api/media-admin/auth/logout`
+
+Requires the session cookie. Revokes the stored session hash and clears the
+browser cookie.
+
+```json
+{
+  "message": "Logged out"
+}
+```
+
+## Frontend Notes
+
+Use `credentials: "include"` when calling session-protected endpoints from the
+browser. If the API is not same-origin with the Next.js app, deploy behind a
+same-origin rewrite/proxy or configure CORS and cookie policy explicitly before
+turning on cross-origin browser access.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
                 "nodemon": "^2.0.20",
                 "resend": "^3.4.0",
                 "sanitize-html": "^2.17.0",
-                "zod": "^3.23.8"
+                "zod": "^3.23.8",
+                "cookie": "^0.7.2"
             },
             "devDependencies": {
                 "@types/cors": "^2.8.17",
@@ -35,7 +36,8 @@
                 "@types/sanitize-html": "^2.16.0",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.6.2",
-                "vitest": "^4.1.6"
+                "vitest": "^4.1.6",
+                "@types/cookie": "^0.6.0"
             }
         },
         "node_modules/@babel/runtime": {
@@ -1233,9 +1235,9 @@
             "license": "MIT"
         },
         "node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4045,6 +4047,20 @@
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@types/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+            "dev": true
+        },
+        "node_modules/express/node_modules/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "engines": {
+                "node": ">= 0.6"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@supabase/supabase-js": "^2.45.4",
         "bcryptjs": "^2.4.3",
+        "cookie": "^0.7.2",
         "cors": "^2.8.5",
         "date-fns": "^2.29.3",
         "dotenv": "^16.0.1",
@@ -30,6 +31,7 @@
     },
     "devDependencies": {
         "@types/cors": "^2.8.17",
+        "@types/cookie": "^0.6.0",
         "@types/express": "^4.17.21",
         "@types/express-validator": "^3.0.0",
         "@types/html-to-text": "^9.0.4",

--- a/src/controllers/media-admin-auth.ts
+++ b/src/controllers/media-admin-auth.ts
@@ -1,0 +1,167 @@
+import { Request, Response } from 'express'
+import { serialize } from 'cookie'
+import { z, ZodError } from 'zod'
+
+import authService from '../services/media-admin-auth'
+import {
+    buildMagicLinkUrl,
+    expiresInHours,
+    expiresInMinutes,
+    generateToken,
+    hashToken,
+    isApprovedAdminEmail,
+    MAGIC_LINK_TOKEN_BYTES,
+    magicLinkTtlMinutes,
+    MEDIA_ADMIN_SESSION_COOKIE,
+    normalizeAdminEmail,
+    sendMediaAdminMagicLink,
+    SESSION_TOKEN_BYTES,
+    sessionTtlHours,
+} from '../lib/media-admin-auth'
+import { handleGenericError } from '../utils/http'
+
+const requestMagicLinkSchema = z.object({
+    email: z.string().email().max(254),
+})
+
+const callbackSchema = z.object({
+    token: z.string().min(20).max(500),
+})
+
+const genericResponse = {
+    message: 'If that email is approved, a sign-in link has been sent.',
+}
+
+const cookieOptions = (maxAgeSeconds: number) => ({
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: maxAgeSeconds,
+})
+
+const requestMagicLink = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = requestMagicLinkSchema.parse(req.body)
+        const email = normalizeAdminEmail(parsed.email)
+
+        if (!isApprovedAdminEmail(email)) {
+            return res.status(200).json(genericResponse)
+        }
+
+        const token = generateToken(MAGIC_LINK_TOKEN_BYTES)
+        await authService.createMagicLink({
+            email,
+            tokenHash: hashToken(token),
+            expiresAt: expiresInMinutes(magicLinkTtlMinutes()),
+            requestedIp: req.ip,
+            userAgent: req.get('user-agent'),
+        })
+
+        await sendMediaAdminMagicLink(email, buildMagicLinkUrl(token))
+
+        return res.status(200).json(genericResponse)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return res.status(400).json({
+                error: 'Invalid payload',
+                details: err.flatten(),
+            })
+        }
+        return handleGenericError(err, res)
+    }
+}
+
+const callback = async (req: Request, res: Response): Promise<Response> => {
+    try {
+        const parsed = callbackSchema.parse(req.body)
+        const magicLink = await authService.findMagicLinkByHash(
+            hashToken(parsed.token)
+        )
+
+        if (!magicLink) {
+            return res.status(401).json({ error: 'Invalid sign-in link' })
+        }
+        if (magicLink.used_at) {
+            return res.status(410).json({ error: 'Sign-in link already used' })
+        }
+        if (new Date(magicLink.expires_at).getTime() <= Date.now()) {
+            return res.status(410).json({ error: 'Sign-in link expired' })
+        }
+        if (!isApprovedAdminEmail(magicLink.email)) {
+            return res.status(403).json({ error: 'Unauthorized' })
+        }
+
+        const claimedMagicLink = await authService.markMagicLinkUsed(
+            magicLink.id
+        )
+        if (!claimedMagicLink) {
+            return res.status(410).json({ error: 'Sign-in link already used' })
+        }
+
+        const sessionToken = generateToken(SESSION_TOKEN_BYTES)
+        const sessionExpiresAt = expiresInHours(sessionTtlHours())
+        await authService.createSession({
+            email: magicLink.email,
+            sessionHash: hashToken(sessionToken),
+            expiresAt: sessionExpiresAt,
+        })
+
+        res.setHeader(
+            'Set-Cookie',
+            serialize(
+                MEDIA_ADMIN_SESSION_COOKIE,
+                sessionToken,
+                cookieOptions(sessionTtlHours() * 60 * 60)
+            )
+        )
+
+        return res.status(200).json({
+            email: magicLink.email,
+            expiresAt: sessionExpiresAt.toISOString(),
+        })
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return res.status(400).json({
+                error: 'Invalid payload',
+                details: err.flatten(),
+            })
+        }
+        return handleGenericError(err, res)
+    }
+}
+
+const getSession = async (req: Request, res: Response): Promise<Response> => {
+    const admin = req.mediaAdmin
+    if (!admin) {
+        return res.status(401).json({ error: 'Authentication required' })
+    }
+
+    return res.status(200).json({
+        email: admin.email,
+        expiresAt: admin.expiresAt,
+    })
+}
+
+const logout = async (req: Request, res: Response): Promise<Response> => {
+    try {
+        const token = req.mediaAdminSessionToken
+        if (token) {
+            await authService.revokeSession(hashToken(token))
+        }
+
+        res.setHeader(
+            'Set-Cookie',
+            serialize(MEDIA_ADMIN_SESSION_COOKIE, '', cookieOptions(0))
+        )
+
+        return res.status(200).json({ message: 'Logged out' })
+    } catch (err) {
+        return handleGenericError(err, res)
+    }
+}
+
+export default { requestMagicLink, callback, getSession, logout }

--- a/src/controllers/media-admin-auth.ts
+++ b/src/controllers/media-admin-auth.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import { serialize } from 'cookie'
+import { parse, serialize } from 'cookie'
 import { z, ZodError } from 'zod'
 
 import authService from '../services/media-admin-auth'
@@ -9,11 +9,13 @@ import {
     expiresInMinutes,
     generateToken,
     hashToken,
+    isProductionEnvironment,
     isApprovedAdminEmail,
     MAGIC_LINK_TOKEN_BYTES,
     magicLinkTtlMinutes,
     MEDIA_ADMIN_SESSION_COOKIE,
     normalizeAdminEmail,
+    requestMinResponseMs,
     sendMediaAdminMagicLink,
     SESSION_TOKEN_BYTES,
     sessionTtlHours,
@@ -34,34 +36,56 @@ const genericResponse = {
 
 const cookieOptions = (maxAgeSeconds: number) => ({
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: isProductionEnvironment(),
     sameSite: 'lax' as const,
     path: '/',
     maxAge: maxAgeSeconds,
 })
 
+const waitForMinimumResponseTime = async (startedAt: number): Promise<void> => {
+    const remaining = requestMinResponseMs() - (Date.now() - startedAt)
+    if (remaining > 0) {
+        await new Promise(resolve => setTimeout(resolve, remaining))
+    }
+}
+
+const createAndSendMagicLink = async (
+    email: string,
+    requestedIp?: string,
+    userAgent?: string
+): Promise<void> => {
+    const token = generateToken(MAGIC_LINK_TOKEN_BYTES)
+    await authService.createMagicLink({
+        email,
+        tokenHash: hashToken(token),
+        expiresAt: expiresInMinutes(magicLinkTtlMinutes()),
+        requestedIp,
+        userAgent,
+    })
+
+    await sendMediaAdminMagicLink(email, buildMagicLinkUrl(token))
+}
+
 const requestMagicLink = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const startedAt = Date.now()
     try {
         const parsed = requestMagicLinkSchema.parse(req.body)
         const email = normalizeAdminEmail(parsed.email)
 
-        if (!isApprovedAdminEmail(email)) {
-            return res.status(200).json(genericResponse)
+        if (isApprovedAdminEmail(email)) {
+            void createAndSendMagicLink(
+                email,
+                req.ip,
+                req.get('user-agent')
+            ).catch(err => {
+                console.error('Media admin magic-link request failed:', err)
+            })
         }
 
-        const token = generateToken(MAGIC_LINK_TOKEN_BYTES)
-        await authService.createMagicLink({
-            email,
-            tokenHash: hashToken(token),
-            expiresAt: expiresInMinutes(magicLinkTtlMinutes()),
-            requestedIp: req.ip,
-            userAgent: req.get('user-agent'),
-        })
-
-        await sendMediaAdminMagicLink(email, buildMagicLinkUrl(token))
+        await waitForMinimumResponseTime(startedAt)
 
         return res.status(200).json(genericResponse)
     } catch (err) {
@@ -71,7 +95,9 @@ const requestMagicLink = async (
                 details: err.flatten(),
             })
         }
-        return handleGenericError(err, res)
+        console.error('Media admin magic-link request failed:', err)
+        await waitForMinimumResponseTime(startedAt)
+        return res.status(200).json(genericResponse)
     }
 }
 
@@ -148,7 +174,10 @@ const getSession = async (req: Request, res: Response): Promise<Response> => {
 
 const logout = async (req: Request, res: Response): Promise<Response> => {
     try {
-        const token = req.mediaAdminSessionToken
+        const cookies = parse(req.headers.cookie || '')
+        const token =
+            req.mediaAdminSessionToken || cookies[MEDIA_ADMIN_SESSION_COOKIE]
+
         if (token) {
             await authService.revokeSession(hashToken(token))
         }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -34,6 +34,8 @@ export const Tables = {
     MEDIA_R2_CONFIGS: 'media_r2_configs',
     MEDIA_CATALOG_ITEMS: 'media_catalog_items',
     MEDIA_AUDIT_LOGS: 'media_audit_logs',
+    MEDIA_ADMIN_MAGIC_LINKS: 'media_admin_magic_links',
+    MEDIA_ADMIN_SESSIONS: 'media_admin_sessions',
 }
 
 // Valid project status values for websites and apps

--- a/src/lib/media-admin-auth.ts
+++ b/src/lib/media-admin-auth.ts
@@ -7,6 +7,7 @@ export const MAGIC_LINK_TOKEN_BYTES = 32
 export const SESSION_TOKEN_BYTES = 32
 export const DEFAULT_MAGIC_LINK_TTL_MINUTES = 15
 export const DEFAULT_SESSION_TTL_HOURS = 12
+export const DEFAULT_REQUEST_MIN_RESPONSE_MS = 350
 
 export const normalizeAdminEmail = (email: string): string =>
     email.trim().toLowerCase()
@@ -33,6 +34,16 @@ export const magicLinkTtlMinutes = (): number =>
 export const sessionTtlHours = (): number =>
     Number(process.env.MEDIA_ADMIN_SESSION_TTL_HOURS) ||
     DEFAULT_SESSION_TTL_HOURS
+
+export const requestMinResponseMs = (): number =>
+    Number.isFinite(Number(process.env.MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS)) &&
+    Number(process.env.MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS) >= 0
+        ? Number(process.env.MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS)
+        : DEFAULT_REQUEST_MIN_RESPONSE_MS
+
+export const isProductionEnvironment = (): boolean =>
+    process.env.NODE_ENV === 'production' ||
+    process.env.NODE_ENVIRONMENT === 'production'
 
 export const expiresInMinutes = (minutes: number): Date =>
     new Date(Date.now() + minutes * 60 * 1000)

--- a/src/lib/media-admin-auth.ts
+++ b/src/lib/media-admin-auth.ts
@@ -1,0 +1,68 @@
+import crypto from 'crypto'
+
+import { sendEmail } from './mailer'
+
+export const MEDIA_ADMIN_SESSION_COOKIE = 'pvs_media_admin_session'
+export const MAGIC_LINK_TOKEN_BYTES = 32
+export const SESSION_TOKEN_BYTES = 32
+export const DEFAULT_MAGIC_LINK_TTL_MINUTES = 15
+export const DEFAULT_SESSION_TTL_HOURS = 12
+
+export const normalizeAdminEmail = (email: string): string =>
+    email.trim().toLowerCase()
+
+export const getApprovedAdminEmails = (): string[] =>
+    (process.env.MEDIA_ADMIN_EMAILS || '')
+        .split(',')
+        .map(normalizeAdminEmail)
+        .filter(Boolean)
+
+export const isApprovedAdminEmail = (email: string): boolean =>
+    getApprovedAdminEmails().includes(normalizeAdminEmail(email))
+
+export const hashToken = (token: string): string =>
+    crypto.createHash('sha256').update(token).digest('hex')
+
+export const generateToken = (bytes: number): string =>
+    crypto.randomBytes(bytes).toString('base64url')
+
+export const magicLinkTtlMinutes = (): number =>
+    Number(process.env.MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES) ||
+    DEFAULT_MAGIC_LINK_TTL_MINUTES
+
+export const sessionTtlHours = (): number =>
+    Number(process.env.MEDIA_ADMIN_SESSION_TTL_HOURS) ||
+    DEFAULT_SESSION_TTL_HOURS
+
+export const expiresInMinutes = (minutes: number): Date =>
+    new Date(Date.now() + minutes * 60 * 1000)
+
+export const expiresInHours = (hours: number): Date =>
+    new Date(Date.now() + hours * 60 * 60 * 1000)
+
+export const buildMagicLinkUrl = (token: string): string => {
+    const baseUrl = process.env.MEDIA_ADMIN_APP_BASE_URL?.trim()
+    if (!baseUrl) {
+        throw new Error('MEDIA_ADMIN_APP_BASE_URL is not configured')
+    }
+
+    const url = new URL('/admin/media/auth/callback', baseUrl)
+    url.searchParams.set('token', token)
+    return url.toString()
+}
+
+export const sendMediaAdminMagicLink = async (
+    email: string,
+    magicLinkUrl: string
+): Promise<void> => {
+    await sendEmail({
+        to: email,
+        subject: "Your Iffer's Pictures media manager sign-in link",
+        text: `Use this secure link to sign in to the Iffer's Pictures media manager. It expires in ${magicLinkTtlMinutes()} minutes.\n\n${magicLinkUrl}`,
+        html: `
+            <p>Use this secure link to sign in to the Iffer's Pictures media manager.</p>
+            <p><a href="${magicLinkUrl}">Sign in to media manager</a></p>
+            <p>This link expires in ${magicLinkTtlMinutes()} minutes.</p>
+        `,
+    })
+}

--- a/src/routes/media-admin-auth.ts
+++ b/src/routes/media-admin-auth.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express'
+import { body } from 'express-validator'
+
+import mediaAdminAuth from '../controllers/media-admin-auth'
+import { requireMediaAdminSession, validateRequest } from './middleware'
+
+const router: Router = Router()
+const BASE_ROUTE = '/api/media-admin/auth'
+
+router.post(
+    `${BASE_ROUTE}/magic-link`,
+    [body('email').isEmail().withMessage('Valid email is required')],
+    validateRequest,
+    mediaAdminAuth.requestMagicLink
+)
+
+router.post(
+    `${BASE_ROUTE}/callback`,
+    [body('token').isString().notEmpty().withMessage('token is required')],
+    validateRequest,
+    mediaAdminAuth.callback
+)
+
+router.get(
+    `${BASE_ROUTE}/session`,
+    requireMediaAdminSession,
+    mediaAdminAuth.getSession
+)
+
+router.post(
+    `${BASE_ROUTE}/logout`,
+    requireMediaAdminSession,
+    mediaAdminAuth.logout
+)
+
+export default router

--- a/src/routes/media-admin-auth.ts
+++ b/src/routes/media-admin-auth.ts
@@ -29,7 +29,6 @@ router.get(
 
 router.post(
     `${BASE_ROUTE}/logout`,
-    requireMediaAdminSession,
     mediaAdminAuth.logout
 )
 

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -1,6 +1,14 @@
 import crypto from 'crypto'
 import { Request, Response, NextFunction } from 'express'
 import { validationResult } from 'express-validator'
+import { parse } from 'cookie'
+
+import {
+    hashToken,
+    isApprovedAdminEmail,
+    MEDIA_ADMIN_SESSION_COOKIE,
+} from '../lib/media-admin-auth'
+import mediaAdminAuthService from '../services/media-admin-auth'
 
 export const validateRequest = (
     req: Request,
@@ -34,4 +42,51 @@ export const requireBlastSecret = (
         return
     }
     next()
+}
+
+export const requireMediaAdminSession = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<void> => {
+    try {
+        const cookies = parse(req.headers.cookie || '')
+        const sessionToken = cookies[MEDIA_ADMIN_SESSION_COOKIE]
+
+        if (!sessionToken) {
+            res.status(401).json({ error: 'Authentication required' })
+            return
+        }
+
+        const session = await mediaAdminAuthService.findSessionByHash(
+            hashToken(sessionToken)
+        )
+
+        if (
+            !session ||
+            session.revoked_at ||
+            new Date(session.expires_at).getTime() <= Date.now()
+        ) {
+            res.status(401).json({ error: 'Session expired' })
+            return
+        }
+
+        if (!isApprovedAdminEmail(session.email)) {
+            res.status(403).json({ error: 'Unauthorized' })
+            return
+        }
+
+        await mediaAdminAuthService.touchSession(session.id)
+
+        req.mediaAdmin = {
+            email: session.email,
+            sessionId: session.id,
+            expiresAt: session.expires_at,
+        }
+        req.mediaAdminSessionToken = sessionToken
+
+        next()
+    } catch (err) {
+        next(err)
+    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import calendlyWebhookRouter from './routes/calendly-webhook'
 import prospectsRouter from './routes/prospects'
 import emailCampaignsRouter from './routes/email-campaigns'
 import seoRouter from './routes/seo'
+import mediaAdminAuthRouter from './routes/media-admin-auth'
 
 import 'dotenv/config'
 
@@ -45,6 +46,7 @@ app.use(calendlyWebhookRouter)
 app.use(prospectsRouter)
 app.use(emailCampaignsRouter)
 app.use(seoRouter)
+app.use(mediaAdminAuthRouter)
 
 // Error handling middleware
 app.use(

--- a/src/services/media-admin-auth.ts
+++ b/src/services/media-admin-auth.ts
@@ -1,0 +1,144 @@
+import { db, Tables } from '../lib/db'
+
+export interface CreateMagicLinkPayload {
+    email: string
+    tokenHash: string
+    expiresAt: Date
+    requestedIp?: string
+    userAgent?: string
+}
+
+export interface MagicLinkRecord {
+    id: string
+    email: string
+    token_hash: string
+    requested_ip: string | null
+    user_agent: string | null
+    expires_at: string
+    used_at: string | null
+    created_at: string
+}
+
+export interface SessionRecord {
+    id: string
+    email: string
+    session_hash: string
+    created_at: string
+    expires_at: string
+    last_seen_at: string | null
+    revoked_at: string | null
+}
+
+const createMagicLink = async ({
+    email,
+    tokenHash,
+    expiresAt,
+    requestedIp,
+    userAgent,
+}: CreateMagicLinkPayload): Promise<MagicLinkRecord> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_ADMIN_MAGIC_LINKS)
+        .insert({
+            email,
+            token_hash: tokenHash,
+            requested_ip: requestedIp ?? null,
+            user_agent: userAgent ?? null,
+            expires_at: expiresAt.toISOString(),
+        })
+        .select()
+        .single()
+
+    if (error) throw error
+    return data as MagicLinkRecord
+}
+
+const findMagicLinkByHash = async (
+    tokenHash: string
+): Promise<MagicLinkRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_ADMIN_MAGIC_LINKS)
+        .select('*')
+        .eq('token_hash', tokenHash)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as MagicLinkRecord | null
+}
+
+const markMagicLinkUsed = async (id: string): Promise<boolean> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_ADMIN_MAGIC_LINKS)
+        .update({ used_at: new Date().toISOString() })
+        .eq('id', id)
+        .is('used_at', null)
+        .select('id')
+        .maybeSingle()
+
+    if (error) throw error
+    return Boolean(data)
+}
+
+const createSession = async ({
+    email,
+    sessionHash,
+    expiresAt,
+}: {
+    email: string
+    sessionHash: string
+    expiresAt: Date
+}): Promise<SessionRecord> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_ADMIN_SESSIONS)
+        .insert({
+            email,
+            session_hash: sessionHash,
+            expires_at: expiresAt.toISOString(),
+        })
+        .select()
+        .single()
+
+    if (error) throw error
+    return data as SessionRecord
+}
+
+const findSessionByHash = async (
+    sessionHash: string
+): Promise<SessionRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_ADMIN_SESSIONS)
+        .select('*')
+        .eq('session_hash', sessionHash)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as SessionRecord | null
+}
+
+const touchSession = async (id: string): Promise<void> => {
+    const { error } = await db
+        .from(Tables.MEDIA_ADMIN_SESSIONS)
+        .update({ last_seen_at: new Date().toISOString() })
+        .eq('id', id)
+
+    if (error) throw error
+}
+
+const revokeSession = async (sessionHash: string): Promise<void> => {
+    const { error } = await db
+        .from(Tables.MEDIA_ADMIN_SESSIONS)
+        .update({ revoked_at: new Date().toISOString() })
+        .eq('session_hash', sessionHash)
+        .is('revoked_at', null)
+
+    if (error) throw error
+}
+
+export default {
+    createMagicLink,
+    findMagicLinkByHash,
+    markMagicLinkUsed,
+    createSession,
+    findSessionByHash,
+    touchSession,
+    revokeSession,
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,10 @@
+declare namespace Express {
+    export interface Request {
+        mediaAdmin?: {
+            email: string
+            sessionId: string
+            expiresAt: string
+        }
+        mediaAdminSessionToken?: string
+    }
+}

--- a/supabase/migrations/20260527175229_create_media_admin_auth_tables.sql
+++ b/supabase/migrations/20260527175229_create_media_admin_auth_tables.sql
@@ -1,0 +1,52 @@
+-- DEV-935: Media admin magic-link auth tables
+--
+-- Stores hashed one-time magic-link tokens and hashed admin session tokens.
+-- Raw tokens never belong in persistence or logs.
+
+CREATE TABLE public.media_admin_magic_links (
+    id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    email         text        NOT NULL,
+    token_hash    text        NOT NULL UNIQUE,
+    requested_ip  text,
+    user_agent    text,
+    expires_at    timestamptz NOT NULL,
+    used_at       timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT timezone('utc', now()),
+    CONSTRAINT media_admin_magic_links_email_lower_check CHECK (
+        email = lower(email)
+    ),
+    CONSTRAINT media_admin_magic_links_expiry_check CHECK (
+        expires_at > created_at
+    )
+);
+
+CREATE INDEX media_admin_magic_links_email_created_at_idx
+    ON public.media_admin_magic_links (email, created_at DESC);
+
+CREATE INDEX media_admin_magic_links_expires_at_idx
+    ON public.media_admin_magic_links (expires_at);
+
+CREATE TABLE public.media_admin_sessions (
+    id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    email          text        NOT NULL,
+    session_hash   text        NOT NULL UNIQUE,
+    created_at     timestamptz NOT NULL DEFAULT timezone('utc', now()),
+    expires_at     timestamptz NOT NULL,
+    last_seen_at   timestamptz,
+    revoked_at     timestamptz,
+    CONSTRAINT media_admin_sessions_email_lower_check CHECK (
+        email = lower(email)
+    ),
+    CONSTRAINT media_admin_sessions_expiry_check CHECK (
+        expires_at > created_at
+    )
+);
+
+CREATE INDEX media_admin_sessions_email_created_at_idx
+    ON public.media_admin_sessions (email, created_at DESC);
+
+CREATE INDEX media_admin_sessions_expires_at_idx
+    ON public.media_admin_sessions (expires_at);
+
+ALTER TABLE public.media_admin_magic_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.media_admin_sessions ENABLE ROW LEVEL SECURITY;

--- a/test/media-admin-auth.test.ts
+++ b/test/media-admin-auth.test.ts
@@ -88,6 +88,7 @@ describe('media admin auth controller', () => {
         process.env.MEDIA_ADMIN_APP_BASE_URL = 'https://ifferspictures.com'
         process.env.MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES = '15'
         process.env.MEDIA_ADMIN_SESSION_TTL_HOURS = '12'
+        process.env.MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS = '0'
         vi.mocked(sendEmail).mockResolvedValue(undefined)
         vi.mocked(mediaAdminAuthService.createMagicLink).mockResolvedValue(
             validMagicLink
@@ -146,7 +147,7 @@ describe('media admin auth controller', () => {
         expect(res.status).toHaveBeenCalledWith(200)
     })
 
-    it('surfaces send failures without creating a session', async () => {
+    it('does not leak send failures through the magic-link response', async () => {
         vi.mocked(sendEmail).mockRejectedValue(new Error('send failed'))
         const res = createResponse()
 
@@ -155,8 +156,29 @@ describe('media admin auth controller', () => {
             res
         )
 
-        expect(res.status).toHaveBeenCalledWith(500)
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.json).toHaveBeenCalledWith({
+            message: 'If that email is approved, a sign-in link has been sent.',
+        })
         expect(mediaAdminAuthService.createSession).not.toHaveBeenCalled()
+    })
+
+    it('does not leak persistence failures through the magic-link response', async () => {
+        vi.mocked(mediaAdminAuthService.createMagicLink).mockRejectedValue(
+            new Error('database unavailable')
+        )
+        const res = createResponse()
+
+        await mediaAdminAuthController.requestMagicLink(
+            createRequest({ body: { email: 'jenn@example.com' } }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.json).toHaveBeenCalledWith({
+            message: 'If that email is approved, a sign-in link has been sent.',
+        })
+        expect(sendEmail).not.toHaveBeenCalled()
     })
 
     it('rejects invalid callback tokens', async () => {
@@ -235,6 +257,21 @@ describe('media admin auth controller', () => {
         expect(res.status).toHaveBeenCalledWith(200)
     })
 
+    it('sets a secure session cookie when NODE_ENVIRONMENT is production', async () => {
+        process.env.NODE_ENVIRONMENT = 'production'
+        vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue(
+            validMagicLink
+        )
+        const res = createResponse()
+
+        await mediaAdminAuthController.callback(
+            createRequest({ body: { token: validCallbackToken } }),
+            res
+        )
+
+        expect(res.setHeader.mock.calls[0][1]).toContain('Secure')
+    })
+
     it('rejects a callback token when the one-time claim loses a race', async () => {
         vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue(
             validMagicLink
@@ -269,6 +306,42 @@ describe('media admin auth controller', () => {
         expect(res.setHeader).toHaveBeenCalledWith(
             'Set-Cookie',
             expect.stringContaining(`${MEDIA_ADMIN_SESSION_COOKIE}=`)
+        )
+        expect(res.status).toHaveBeenCalledWith(200)
+    })
+
+    it('logs out by revoking a stale cookie even without request admin context', async () => {
+        const res = createResponse()
+
+        await mediaAdminAuthController.logout(
+            createRequest({
+                headers: {
+                    cookie: serialize(
+                        MEDIA_ADMIN_SESSION_COOKIE,
+                        validSessionToken
+                    ),
+                },
+            }),
+            res
+        )
+
+        expect(mediaAdminAuthService.revokeSession).toHaveBeenCalledWith(
+            hashToken(validSessionToken)
+        )
+        expect(res.setHeader.mock.calls[0][1]).toContain(
+            `${MEDIA_ADMIN_SESSION_COOKIE}=`
+        )
+        expect(res.status).toHaveBeenCalledWith(200)
+    })
+
+    it('clears the session cookie on logout even when no token is present', async () => {
+        const res = createResponse()
+
+        await mediaAdminAuthController.logout(createRequest({}), res)
+
+        expect(mediaAdminAuthService.revokeSession).not.toHaveBeenCalled()
+        expect(res.setHeader.mock.calls[0][1]).toContain(
+            `${MEDIA_ADMIN_SESSION_COOKIE}=`
         )
         expect(res.status).toHaveBeenCalledWith(200)
     })

--- a/test/media-admin-auth.test.ts
+++ b/test/media-admin-auth.test.ts
@@ -1,0 +1,373 @@
+import { Request, Response } from 'express'
+import { serialize } from 'cookie'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import mediaAdminAuthController from '../src/controllers/media-admin-auth'
+import { requireMediaAdminSession } from '../src/routes/middleware'
+import mediaAdminAuthService from '../src/services/media-admin-auth'
+import { sendEmail } from '../src/lib/mailer'
+import {
+    hashToken,
+    MEDIA_ADMIN_SESSION_COOKIE,
+} from '../src/lib/media-admin-auth'
+
+const validCallbackToken = 'valid-token-1234567890'
+const validSessionToken = 'session-token-1234567890'
+
+vi.mock('../src/services/media-admin-auth', () => ({
+    default: {
+        createMagicLink: vi.fn(),
+        findMagicLinkByHash: vi.fn(),
+        markMagicLinkUsed: vi.fn(),
+        createSession: vi.fn(),
+        findSessionByHash: vi.fn(),
+        touchSession: vi.fn(),
+        revokeSession: vi.fn(),
+    },
+}))
+
+vi.mock('../src/lib/mailer', () => ({
+    sendEmail: vi.fn(),
+}))
+
+const createResponse = () => {
+    const res = {
+        status: vi.fn(),
+        json: vi.fn(),
+        setHeader: vi.fn(),
+    }
+    res.status.mockReturnValue(res)
+    res.json.mockReturnValue(res)
+    return res as unknown as Response & {
+        status: ReturnType<typeof vi.fn>
+        json: ReturnType<typeof vi.fn>
+        setHeader: ReturnType<typeof vi.fn>
+    }
+}
+
+const createRequest = ({
+    body = {},
+    headers = {},
+    ip = '127.0.0.1',
+}: {
+    body?: unknown
+    headers?: Record<string, string>
+    ip?: string
+}): Request =>
+    ({
+        body,
+        headers,
+        ip,
+        get: (name: string) => headers[name.toLowerCase()],
+    }) as unknown as Request
+
+const validMagicLink = {
+    id: 'magic-link-1',
+    email: 'jenn@example.com',
+    token_hash: hashToken(validCallbackToken),
+    requested_ip: '127.0.0.1',
+    user_agent: 'vitest',
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    used_at: null,
+    created_at: new Date().toISOString(),
+}
+
+const validSession = {
+    id: 'session-1',
+    email: 'jenn@example.com',
+    session_hash: hashToken(validSessionToken),
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    last_seen_at: null,
+    revoked_at: null,
+}
+
+describe('media admin auth controller', () => {
+    beforeEach(() => {
+        process.env.MEDIA_ADMIN_EMAILS = 'jenn@example.com,phil@example.com'
+        process.env.MEDIA_ADMIN_APP_BASE_URL = 'https://ifferspictures.com'
+        process.env.MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES = '15'
+        process.env.MEDIA_ADMIN_SESSION_TTL_HOURS = '12'
+        vi.mocked(sendEmail).mockResolvedValue(undefined)
+        vi.mocked(mediaAdminAuthService.createMagicLink).mockResolvedValue(
+            validMagicLink
+        )
+        vi.mocked(mediaAdminAuthService.markMagicLinkUsed).mockResolvedValue(
+            true
+        )
+        vi.mocked(mediaAdminAuthService.createSession).mockResolvedValue(
+            validSession
+        )
+        vi.mocked(mediaAdminAuthService.revokeSession).mockResolvedValue(
+            undefined
+        )
+    })
+
+    it('does not leak whether an email is approved', async () => {
+        const res = createResponse()
+
+        await mediaAdminAuthController.requestMagicLink(
+            createRequest({ body: { email: 'unknown@example.com' } }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.json).toHaveBeenCalledWith({
+            message: 'If that email is approved, a sign-in link has been sent.',
+        })
+        expect(mediaAdminAuthService.createMagicLink).not.toHaveBeenCalled()
+        expect(sendEmail).not.toHaveBeenCalled()
+    })
+
+    it('creates and sends a magic link for approved admins', async () => {
+        const res = createResponse()
+
+        await mediaAdminAuthController.requestMagicLink(
+            createRequest({
+                body: { email: 'Jenn@Example.com' },
+                headers: { 'user-agent': 'vitest' },
+            }),
+            res
+        )
+
+        expect(mediaAdminAuthService.createMagicLink).toHaveBeenCalledWith(
+            expect.objectContaining({
+                email: 'jenn@example.com',
+                requestedIp: '127.0.0.1',
+                userAgent: 'vitest',
+            })
+        )
+        expect(sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                to: 'jenn@example.com',
+                subject: "Your Iffer's Pictures media manager sign-in link",
+            })
+        )
+        expect(res.status).toHaveBeenCalledWith(200)
+    })
+
+    it('surfaces send failures without creating a session', async () => {
+        vi.mocked(sendEmail).mockRejectedValue(new Error('send failed'))
+        const res = createResponse()
+
+        await mediaAdminAuthController.requestMagicLink(
+            createRequest({ body: { email: 'jenn@example.com' } }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(mediaAdminAuthService.createSession).not.toHaveBeenCalled()
+    })
+
+    it('rejects invalid callback tokens', async () => {
+        vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue(
+            null
+        )
+        const res = createResponse()
+
+        await mediaAdminAuthController.callback(
+            createRequest({ body: { token: 'valid-looking-invalid-token' } }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({ error: 'Invalid sign-in link' })
+    })
+
+    it('rejects already-used callback tokens', async () => {
+        vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue({
+            ...validMagicLink,
+            used_at: new Date().toISOString(),
+        })
+        const res = createResponse()
+
+        await mediaAdminAuthController.callback(
+            createRequest({ body: { token: validCallbackToken } }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(410)
+        expect(res.json).toHaveBeenCalledWith({
+            error: 'Sign-in link already used',
+        })
+    })
+
+    it('rejects expired callback tokens', async () => {
+        vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue({
+            ...validMagicLink,
+            expires_at: new Date(Date.now() - 60_000).toISOString(),
+        })
+        const res = createResponse()
+
+        await mediaAdminAuthController.callback(
+            createRequest({ body: { token: validCallbackToken } }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(410)
+        expect(res.json).toHaveBeenCalledWith({
+            error: 'Sign-in link expired',
+        })
+    })
+
+    it('creates an HTTP-only session cookie for a valid callback token', async () => {
+        vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue(
+            validMagicLink
+        )
+        const res = createResponse()
+
+        await mediaAdminAuthController.callback(
+            createRequest({ body: { token: validCallbackToken } }),
+            res
+        )
+
+        expect(mediaAdminAuthService.markMagicLinkUsed).toHaveBeenCalledWith(
+            validMagicLink.id
+        )
+        expect(mediaAdminAuthService.createSession).toHaveBeenCalledWith(
+            expect.objectContaining({ email: 'jenn@example.com' })
+        )
+        expect(res.setHeader).toHaveBeenCalledWith(
+            'Set-Cookie',
+            expect.stringContaining(`${MEDIA_ADMIN_SESSION_COOKIE}=`)
+        )
+        expect(res.setHeader.mock.calls[0][1]).toContain('HttpOnly')
+        expect(res.status).toHaveBeenCalledWith(200)
+    })
+
+    it('rejects a callback token when the one-time claim loses a race', async () => {
+        vi.mocked(mediaAdminAuthService.findMagicLinkByHash).mockResolvedValue(
+            validMagicLink
+        )
+        vi.mocked(mediaAdminAuthService.markMagicLinkUsed).mockResolvedValue(
+            false
+        )
+        const res = createResponse()
+
+        await mediaAdminAuthController.callback(
+            createRequest({ body: { token: validCallbackToken } }),
+            res
+        )
+
+        expect(mediaAdminAuthService.createSession).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledWith(410)
+        expect(res.json).toHaveBeenCalledWith({
+            error: 'Sign-in link already used',
+        })
+    })
+
+    it('logs out by revoking the current session and clearing cookie', async () => {
+        const req = createRequest({}) as Request
+        req.mediaAdminSessionToken = validSessionToken
+        const res = createResponse()
+
+        await mediaAdminAuthController.logout(req, res)
+
+        expect(mediaAdminAuthService.revokeSession).toHaveBeenCalledWith(
+            hashToken(validSessionToken)
+        )
+        expect(res.setHeader).toHaveBeenCalledWith(
+            'Set-Cookie',
+            expect.stringContaining(`${MEDIA_ADMIN_SESSION_COOKIE}=`)
+        )
+        expect(res.status).toHaveBeenCalledWith(200)
+    })
+})
+
+describe('requireMediaAdminSession', () => {
+    beforeEach(() => {
+        process.env.MEDIA_ADMIN_EMAILS = 'jenn@example.com'
+        vi.mocked(mediaAdminAuthService.touchSession).mockResolvedValue(undefined)
+    })
+
+    it('rejects unauthenticated requests', async () => {
+        const res = createResponse()
+        const next = vi.fn()
+
+        await requireMediaAdminSession(createRequest({}), res, next)
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({
+            error: 'Authentication required',
+        })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it('rejects expired sessions', async () => {
+        vi.mocked(mediaAdminAuthService.findSessionByHash).mockResolvedValue({
+            ...validSession,
+            expires_at: new Date(Date.now() - 60_000).toISOString(),
+        })
+        const res = createResponse()
+        const next = vi.fn()
+
+        await requireMediaAdminSession(
+            createRequest({
+                headers: {
+                    cookie: serialize(
+                        MEDIA_ADMIN_SESSION_COOKIE,
+                        validSessionToken
+                    ),
+                },
+            }),
+            res,
+            next
+        )
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({ error: 'Session expired' })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it('rejects sessions for no-longer-approved admins', async () => {
+        process.env.MEDIA_ADMIN_EMAILS = 'phil@example.com'
+        vi.mocked(mediaAdminAuthService.findSessionByHash).mockResolvedValue(
+            validSession
+        )
+        const res = createResponse()
+        const next = vi.fn()
+
+        await requireMediaAdminSession(
+            createRequest({
+                headers: {
+                    cookie: serialize(
+                        MEDIA_ADMIN_SESSION_COOKIE,
+                        validSessionToken
+                    ),
+                },
+            }),
+            res,
+            next
+        )
+
+        expect(res.status).toHaveBeenCalledWith(403)
+        expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it('sets request admin context for valid sessions', async () => {
+        vi.mocked(mediaAdminAuthService.findSessionByHash).mockResolvedValue(
+            validSession
+        )
+        const req = createRequest({
+            headers: {
+                cookie: serialize(MEDIA_ADMIN_SESSION_COOKIE, validSessionToken),
+            },
+        })
+        const res = createResponse()
+        const next = vi.fn()
+
+        await requireMediaAdminSession(req, res, next)
+
+        expect(mediaAdminAuthService.touchSession).toHaveBeenCalledWith(
+            validSession.id
+        )
+        expect(req.mediaAdmin).toEqual({
+            email: 'jenn@example.com',
+            sessionId: validSession.id,
+            expiresAt: validSession.expires_at,
+        })
+        expect(req.mediaAdminSessionToken).toBe(validSessionToken)
+        expect(next).toHaveBeenCalledOnce()
+    })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -16,6 +16,7 @@ const externalServiceEnvKeys = [
     'MEDIA_ADMIN_APP_BASE_URL',
     'MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES',
     'MEDIA_ADMIN_SESSION_TTL_HOURS',
+    'MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS',
 ]
 
 const buildTestEnv = (): NodeJS.ProcessEnv => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -9,8 +9,13 @@ const externalServiceEnvKeys = [
     'GMAIL_CLIENT_ID',
     'GMAIL_CLIENT_SECRET',
     'GMAIL_REFRESH_TOKEN',
+    'GMAIL_APP_PASSWORD',
     'RESEND_API_KEY',
     'CALENDLY_API_TOKEN',
+    'MEDIA_ADMIN_EMAILS',
+    'MEDIA_ADMIN_APP_BASE_URL',
+    'MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES',
+    'MEDIA_ADMIN_SESSION_TTL_HOURS',
 ]
 
 const buildTestEnv = (): NodeJS.ProcessEnv => {


### PR DESCRIPTION
## Summary
- Adds media admin magic-link request, callback, session, and logout routes.
- Persists hashed one-time link tokens and hashed session tokens in new Supabase tables.
- Adds reusable `requireMediaAdminSession` middleware for future protected media endpoints.
- Documents the frontend auth contract and required env vars.

## Validation
- `npm run build`
- `/Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run`

## Visual QA
Not applicable for this server API ticket. The user-visible email body is plain transactional HTML and the frontend callback UI remains a later app task.