### PR TITLE
DEV-931 Add R2 presigned media uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `/api/media-admin/auth/callback` | POST | Exchange a one-time magic-link token for an HTTP-only media admin session cookie. | `controllers/media-admin-auth.callback` |
 | `/api/media-admin/auth/session` | GET | Return the current media admin session when the session cookie is valid. | `controllers/media-admin-auth.getSession` |
 | `/api/media-admin/auth/logout` | POST | Revoke the current media admin session and clear the cookie. | `controllers/media-admin-auth.logout` |
+| `/api/media/:websiteSlug/admin/uploads/presign` | POST | Create a protected, short-lived Cloudflare R2 direct-upload URL. | `controllers/media.presignUpload` |
 
 > `routes/recaptcha.ts` is currently a placeholder; wire it before exposing any verification endpoint.
 
@@ -117,6 +118,8 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `R2_ACCOUNT_ID` | Cloudflare account id for future R2 S3-compatible API calls. |
 | `R2_BUCKET_NAME` | Fallback Cloudflare R2 bucket name for media manager features when no per-client config exists. |
 | `R2_PUBLIC_BASE_URL` | Fallback public base URL for R2 media objects when no per-client config exists. |
+| `R2_PRESIGN_EXPIRES_SECONDS` | Optional R2 presigned upload expiry; defaults to 900 seconds. |
+| `MEDIA_MAX_UPLOAD_BYTES` | Optional maximum media upload size; defaults to 10MB. |
 | `MEDIA_ADMIN_EMAILS` | Comma-separated approved media manager admin email addresses. |
 | `MEDIA_ADMIN_APP_BASE_URL` | Frontend base URL used when generating media admin magic links. |
 | `MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES` | Optional magic-link expiry window; defaults to 15 minutes. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
                 "resend": "^3.4.0",
                 "sanitize-html": "^2.17.0",
                 "zod": "^3.23.8",
-                "cookie": "^0.7.2"
+                "cookie": "^0.7.2",
+                "@aws-sdk/client-s3": "^3.1055.0",
+                "@aws-sdk/s3-request-presigner": "^3.1055.0"
             },
             "devDependencies": {
                 "@types/cors": "^2.8.17",
@@ -4061,6 +4063,686 @@
             "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/crc32c": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+            "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+            "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+            "dependencies": {
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.1055.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1055.0.tgz",
+            "integrity": "sha512-FxVwuw86c2Mw4p+0tOtoE+1sDTk+eOBZD/NwwK+wwx1gHkdO/EYSv231O9A1YM8HPjUrI0vZ/hP/szckBxHW0A==",
+            "dependencies": {
+                "@aws-crypto/sha1-browser": "5.2.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/credential-provider-node": "^3.972.45",
+                "@aws-sdk/middleware-bucket-endpoint": "^3.972.16",
+                "@aws-sdk/middleware-expect-continue": "^3.972.13",
+                "@aws-sdk/middleware-flexible-checksums": "^3.974.22",
+                "@aws-sdk/middleware-location-constraint": "^3.972.11",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.43",
+                "@aws-sdk/middleware-ssec": "^3.972.11",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/fetch-http-handler": "^5.4.3",
+                "@smithy/node-http-handler": "^4.7.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.974.14",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
+            "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.9",
+                "@aws-sdk/xml-builder": "^3.972.26",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/core": "^3.24.3",
+                "@smithy/signature-v4": "^5.4.2",
+                "@smithy/types": "^4.14.2",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/crc64-nvme": {
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+            "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
+            "dependencies": {
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
+            "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.42",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
+            "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/fetch-http-handler": "^5.4.3",
+                "@smithy/node-http-handler": "^4.7.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.972.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
+            "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/credential-provider-env": "^3.972.40",
+                "@aws-sdk/credential-provider-http": "^3.972.42",
+                "@aws-sdk/credential-provider-login": "^3.972.44",
+                "@aws-sdk/credential-provider-process": "^3.972.40",
+                "@aws-sdk/credential-provider-sso": "^3.972.44",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.44",
+                "@aws-sdk/nested-clients": "^3.997.12",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/credential-provider-imds": "^4.3.2",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.44.tgz",
+            "integrity": "sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/nested-clients": "^3.997.12",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.45",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
+            "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.40",
+                "@aws-sdk/credential-provider-http": "^3.972.42",
+                "@aws-sdk/credential-provider-ini": "^3.972.44",
+                "@aws-sdk/credential-provider-process": "^3.972.40",
+                "@aws-sdk/credential-provider-sso": "^3.972.44",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.44",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/credential-provider-imds": "^4.3.2",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
+            "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.972.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
+            "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/nested-clients": "^3.997.12",
+                "@aws-sdk/token-providers": "3.1054.0",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
+            "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/nested-clients": "^3.997.12",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.972.16",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.16.tgz",
+            "integrity": "sha512-FhasMTBDBmMN7EEa1hUeHwo5p5Mv3Dm8w0VEbdXX/6ola/uyhRuJt8zGkH09mLTmab20USTzEpPqyqEoe1MqNg==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.13.tgz",
+            "integrity": "sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-flexible-checksums": {
+            "version": "3.974.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.22.tgz",
+            "integrity": "sha512-ot1kZ1JGHUxcXPOARhej/n/+Odfx9VPt60pNrUq8Lf/U2blIF3+uj5v56gw76VD70dZvrfeLNo9jKz6pQJfOlA==",
+            "dependencies": {
+                "@aws-crypto/crc32": "5.2.0",
+                "@aws-crypto/crc32c": "5.2.0",
+                "@aws-crypto/util": "5.2.0",
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/crc64-nvme": "^3.972.9",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-location-constraint": {
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+            "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.972.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.43.tgz",
+            "integrity": "sha512-CBmixMY36JdAdt9ALgm7yVlvOXGUCHt9Z2kn5p9XVO5StO6HCH+cayV7YYV1CDLsXvVyebaXgBmif9wHoxCeNA==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-ssec": {
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+            "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
+            "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/fetch-http-handler": "^5.4.3",
+                "@smithy/node-http-handler": "^4.7.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/s3-request-presigner": {
+            "version": "3.1055.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1055.0.tgz",
+            "integrity": "sha512-/qbh/nG6PQG4CxFYS9IDkUXtPsDcYCjuPaLejhyG7Cw2Ary6XqIshtrWlUjLPIc163IueHXQR/aq2WQt9f0OxA==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.29",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.29.tgz",
+            "integrity": "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/signature-v4": "^5.4.2",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.1054.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
+            "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.14",
+                "@aws-sdk/nested-clients": "^3.997.12",
+                "@aws-sdk/types": "^3.973.9",
+                "@smithy/core": "^3.24.3",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.973.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+            "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+            "dependencies": {
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.26",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+            "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+            "dependencies": {
+                "@smithy/types": "^4.14.2",
+                "fast-xml-parser": "5.7.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ]
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.24.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+            "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+            "dependencies": {
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.5.tgz",
+            "integrity": "sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==",
+            "dependencies": {
+                "@smithy/core": "^3.24.5",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
+            "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+            "dependencies": {
+                "@smithy/core": "^3.24.5",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
+            "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+            "dependencies": {
+                "@smithy/core": "^3.24.5",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
+            "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+            "dependencies": {
+                "@smithy/core": "^3.24.5",
+                "@smithy/types": "^4.14.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+            "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/bowser": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.7",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/strnum": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+            "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ]
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "engines": {
+                "node": ">=16.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "@aws-sdk/client-s3": "^3.1055.0",
+        "@aws-sdk/s3-request-presigner": "^3.1055.0",
         "@supabase/supabase-js": "^2.45.4",
         "bcryptjs": "^2.4.3",
         "cookie": "^0.7.2",
@@ -30,8 +32,8 @@
         "zod": "^3.23.8"
     },
     "devDependencies": {
-        "@types/cors": "^2.8.17",
         "@types/cookie": "^0.6.0",
+        "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/express-validator": "^3.0.0",
         "@types/html-to-text": "^9.0.4",

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from 'express'
+import { z, ZodError } from 'zod'
+
+import mediaR2Service from '../services/media-r2'
+import { MediaValidationError } from '../lib/media-r2'
+import { handleGenericError } from '../utils/http'
+
+const presignUploadSchema = z.object({
+    filename: z.string().trim().min(1).max(255),
+    content_type: z.string().trim().min(1).max(100),
+    folder: z.string().trim().max(500).optional(),
+    size: z.number().int().positive(),
+})
+
+const sendMediaError = (
+    res: Response,
+    status: number,
+    code: string,
+    message: string,
+    details?: Record<string, unknown>
+): Response =>
+    res.status(status).json({
+        error: {
+            code,
+            message,
+            ...(details && { details }),
+        },
+    })
+
+const presignUpload = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const { websiteSlug } = req.params
+        const parsed = presignUploadSchema.parse(req.body)
+        const result = await mediaR2Service.createPresignedUpload({
+            websiteSlug,
+            filename: parsed.filename,
+            contentType: parsed.content_type,
+            folder: parsed.folder,
+            size: parsed.size,
+        })
+
+        return res.status(200).json(result)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid upload presign payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+export default { presignUpload }

--- a/src/lib/media-r2.ts
+++ b/src/lib/media-r2.ts
@@ -1,0 +1,168 @@
+import crypto from 'crypto'
+
+export const ALLOWED_UPLOAD_CONTENT_TYPES = [
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+] as const
+
+export type AllowedUploadContentType =
+    (typeof ALLOWED_UPLOAD_CONTENT_TYPES)[number]
+
+export const DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+export const DEFAULT_PRESIGN_EXPIRES_SECONDS = 15 * 60
+
+const CONTENT_TYPE_EXTENSIONS: Record<AllowedUploadContentType, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+}
+
+export class MediaValidationError extends Error {
+    status: number
+    code: string
+    details?: Record<string, unknown>
+
+    constructor(
+        status: number,
+        code: string,
+        message: string,
+        details?: Record<string, unknown>
+    ) {
+        super(message)
+        this.status = status
+        this.code = code
+        this.details = details
+    }
+}
+
+export const maxUploadBytes = (): number => {
+    const parsed = Number(process.env.MEDIA_MAX_UPLOAD_BYTES)
+    return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : DEFAULT_MAX_UPLOAD_BYTES
+}
+
+export const presignExpiresSeconds = (): number => {
+    const parsed = Number(process.env.R2_PRESIGN_EXPIRES_SECONDS)
+    return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : DEFAULT_PRESIGN_EXPIRES_SECONDS
+}
+
+export const isAllowedUploadContentType = (
+    contentType: string
+): contentType is AllowedUploadContentType =>
+    ALLOWED_UPLOAD_CONTENT_TYPES.includes(
+        contentType as AllowedUploadContentType
+    )
+
+const kebabCase = (value: string): string =>
+    value
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .replace(/-{2,}/g, '-')
+
+const normalizeFolder = (folder?: string): string => {
+    if (!folder) return ''
+
+    return folder
+        .split('/')
+        .map(segment => kebabCase(segment))
+        .filter(Boolean)
+        .join('/')
+}
+
+const normalizeKeyPrefix = (keyPrefix?: string): string => {
+    if (!keyPrefix) return ''
+    return normalizeFolder(keyPrefix)
+}
+
+export const normalizeFilename = (
+    filename: string,
+    contentType: AllowedUploadContentType
+): string => {
+    const fallbackExtension = CONTENT_TYPE_EXTENSIONS[contentType]
+    const lastSegment = filename.split(/[\\/]/).filter(Boolean).pop() || ''
+    const withoutQuery = lastSegment.split('?')[0].split('#')[0]
+    const extensionMatch = withoutQuery.match(/\.([a-z0-9]+)$/i)
+    const extension = fallbackExtension
+    const baseName = extensionMatch
+        ? withoutQuery.slice(0, -extensionMatch[0].length)
+        : withoutQuery
+    const safeBase = kebabCase(baseName) || 'upload'
+
+    return `${safeBase}.${extension || fallbackExtension}`
+}
+
+export const buildR2ObjectKey = ({
+    filename,
+    contentType,
+    folder,
+    keyPrefix,
+    now = Date.now(),
+    uniqueSuffix = crypto.randomBytes(6).toString('hex'),
+}: {
+    filename: string
+    contentType: AllowedUploadContentType
+    folder?: string
+    keyPrefix?: string
+    now?: number
+    uniqueSuffix?: string
+}): string => {
+    const safeFilename = normalizeFilename(filename, contentType)
+    const safeFolder = normalizeFolder(folder)
+    const safePrefix = normalizeKeyPrefix(keyPrefix)
+    const filenameWithCollisionGuard = `${now}-${uniqueSuffix}-${safeFilename}`
+
+    return [safePrefix, safeFolder, filenameWithCollisionGuard]
+        .filter(Boolean)
+        .join('/')
+}
+
+export const joinPublicUrl = (publicBaseUrl: string, key: string): string =>
+    `${publicBaseUrl.replace(/\/+$/g, '')}/${key}`
+
+export const validateUploadInput = ({
+    contentType,
+    size,
+}: {
+    contentType: string
+    size: number
+}): AllowedUploadContentType => {
+    if (!isAllowedUploadContentType(contentType)) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_content_type',
+            'Unsupported upload content type.',
+            {
+                field: 'content_type',
+                allowed: ALLOWED_UPLOAD_CONTENT_TYPES,
+            }
+        )
+    }
+
+    const maxBytes = maxUploadBytes()
+    if (!Number.isFinite(size) || size <= 0) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_upload_size',
+            'Upload size must be a positive number.',
+            { field: 'size' }
+        )
+    }
+
+    if (size > maxBytes) {
+        throw new MediaValidationError(
+            413,
+            'media.file_too_large',
+            'Upload exceeds the configured maximum size.',
+            { field: 'size', size, max_size: maxBytes }
+        )
+    }
+
+    return contentType
+}

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express'
+import { body, param } from 'express-validator'
+
+import media from '../controllers/media'
+import { requireMediaAdminSession, validateRequest } from './middleware'
+
+const router: Router = Router()
+const BASE_ROUTE = '/api/media'
+
+router.post(
+    `${BASE_ROUTE}/:websiteSlug/admin/uploads/presign`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        body('filename')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('filename is required'),
+        body('content_type')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('content_type is required'),
+        body('folder')
+            .optional()
+            .isString()
+            .withMessage('folder must be a string'),
+        body('size')
+            .isInt({ min: 1 })
+            .withMessage('size must be a positive integer'),
+    ],
+    validateRequest,
+    media.presignUpload
+)
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import prospectsRouter from './routes/prospects'
 import emailCampaignsRouter from './routes/email-campaigns'
 import seoRouter from './routes/seo'
 import mediaAdminAuthRouter from './routes/media-admin-auth'
+import mediaRouter from './routes/media'
 
 import 'dotenv/config'
 
@@ -47,6 +48,7 @@ app.use(prospectsRouter)
 app.use(emailCampaignsRouter)
 app.use(seoRouter)
 app.use(mediaAdminAuthRouter)
+app.use(mediaRouter)
 
 // Error handling middleware
 app.use(

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -1,0 +1,168 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+import { COLUMNS, db, Tables } from '../lib/db'
+import {
+    buildR2ObjectKey,
+    joinPublicUrl,
+    presignExpiresSeconds,
+    validateUploadInput,
+} from '../lib/media-r2'
+
+export interface PresignUploadInput {
+    websiteSlug: string
+    filename: string
+    contentType: string
+    folder?: string
+    size: number
+}
+
+export interface PresignUploadResult {
+    presigned_url: string
+    public_url: string
+    r2_key: string
+    expires_at: string
+}
+
+interface WebsiteRecord {
+    id: string
+    client_id: string
+}
+
+interface R2ConfigRecord {
+    bucket: string
+    public_base_url: string
+    key_prefix: string | null
+}
+
+interface ResolvedR2Config {
+    bucket: string
+    publicBaseUrl: string
+    keyPrefix: string
+}
+
+const getWebsiteBySlug = async (
+    websiteSlug: string
+): Promise<WebsiteRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.WEBSITES)
+        .select('id, client_id')
+        .eq(COLUMNS.WEBSITE_SLUG, websiteSlug)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as WebsiteRecord | null
+}
+
+const getWebsiteR2Config = async (
+    website: WebsiteRecord
+): Promise<R2ConfigRecord | null> => {
+    const { data: websiteConfig, error: websiteError } = await db
+        .from(Tables.MEDIA_R2_CONFIGS)
+        .select('bucket, public_base_url, key_prefix')
+        .eq('website_id', website.id)
+        .maybeSingle()
+
+    if (websiteError) throw websiteError
+    if (websiteConfig) return websiteConfig as R2ConfigRecord
+
+    const { data: clientConfig, error: clientError } = await db
+        .from(Tables.MEDIA_R2_CONFIGS)
+        .select('bucket, public_base_url, key_prefix')
+        .eq('client_id', website.client_id)
+        .is('website_id', null)
+        .maybeSingle()
+
+    if (clientError) throw clientError
+    return clientConfig as R2ConfigRecord | null
+}
+
+const resolveR2Config = async (
+    website: WebsiteRecord
+): Promise<ResolvedR2Config> => {
+    const persistedConfig = await getWebsiteR2Config(website)
+    const bucket = persistedConfig?.bucket || process.env.R2_BUCKET_NAME
+    const publicBaseUrl =
+        persistedConfig?.public_base_url || process.env.R2_PUBLIC_BASE_URL
+    const keyPrefix = persistedConfig?.key_prefix || ''
+
+    if (!bucket || !publicBaseUrl) {
+        const err = new Error('R2 media configuration is not available') as Error & {
+            status?: number
+        }
+        err.status = 503
+        throw err
+    }
+
+    return { bucket, publicBaseUrl, keyPrefix }
+}
+
+const createR2Client = (): S3Client => {
+    const accessKeyId = process.env.R2_ACCESS_KEY_ID
+    const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY
+    const accountId = process.env.R2_ACCOUNT_ID
+
+    if (!accessKeyId || !secretAccessKey || !accountId) {
+        const err = new Error('R2 credentials are not configured') as Error & {
+            status?: number
+        }
+        err.status = 503
+        throw err
+    }
+
+    return new S3Client({
+        region: 'auto',
+        endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+        credentials: {
+            accessKeyId,
+            secretAccessKey,
+        },
+    })
+}
+
+const createPresignedUpload = async ({
+    websiteSlug,
+    filename,
+    contentType,
+    folder,
+    size,
+}: PresignUploadInput): Promise<PresignUploadResult> => {
+    const website = await getWebsiteBySlug(websiteSlug)
+    if (!website) {
+        const err = new Error('Website not found') as Error & { status?: number }
+        err.status = 404
+        throw err
+    }
+
+    const allowedContentType = validateUploadInput({ contentType, size })
+    const config = await resolveR2Config(website)
+    const expiresIn = presignExpiresSeconds()
+    const expiresAt = new Date(Date.now() + expiresIn * 1000)
+    const key = buildR2ObjectKey({
+        filename,
+        contentType: allowedContentType,
+        folder,
+        keyPrefix: config.keyPrefix,
+    })
+
+    const command = new PutObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+        ContentType: allowedContentType,
+    })
+
+    const presignedUrl = await getSignedUrl(createR2Client(), command, {
+        expiresIn,
+    })
+
+    return {
+        presigned_url: presignedUrl,
+        public_url: joinPublicUrl(config.publicBaseUrl, key),
+        r2_key: key,
+        expires_at: expiresAt.toISOString(),
+    }
+}
+
+export default {
+    createPresignedUpload,
+}

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -113,6 +113,7 @@ const createR2Client = (): S3Client => {
     return new S3Client({
         region: 'auto',
         endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+        requestChecksumCalculation: 'WHEN_REQUIRED',
         credentials: {
             accessKeyId,
             secretAccessKey,
@@ -149,10 +150,12 @@ const createPresignedUpload = async ({
         Bucket: config.bucket,
         Key: key,
         ContentType: allowedContentType,
+        ContentLength: size,
     })
 
     const presignedUrl = await getSignedUrl(createR2Client(), command, {
         expiresIn,
+        signableHeaders: new Set(['content-type', 'content-length']),
     })
 
     return {

--- a/test/media-r2-presigner.test.ts
+++ b/test/media-r2-presigner.test.ts
@@ -1,0 +1,36 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { describe, expect, it } from 'vitest'
+
+describe('R2 presigner options', () => {
+    it('signs content headers without adding empty-body checksum params', async () => {
+        const client = new S3Client({
+            region: 'auto',
+            endpoint: 'https://test-account.r2.cloudflarestorage.com',
+            requestChecksumCalculation: 'WHEN_REQUIRED',
+            credentials: {
+                accessKeyId: 'test-access-key',
+                secretAccessKey: 'test-secret-key',
+            },
+        })
+        const command = new PutObjectCommand({
+            Bucket: 'test-bucket',
+            Key: 'events/test.jpg',
+            ContentType: 'image/jpeg',
+            ContentLength: 123456,
+        })
+
+        const signedUrl = await getSignedUrl(client, command, {
+            expiresIn: 900,
+            signableHeaders: new Set(['content-type', 'content-length']),
+        })
+
+        const url = new URL(signedUrl)
+
+        expect(url.searchParams.get('X-Amz-SignedHeaders')).toBe(
+            'content-length;content-type;host'
+        )
+        expect(url.searchParams.has('x-amz-checksum-crc32')).toBe(false)
+        expect(url.searchParams.has('x-amz-sdk-checksum-algorithm')).toBe(false)
+    })
+})

--- a/test/media-r2-service.test.ts
+++ b/test/media-r2-service.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+    from: vi.fn(),
+    getSignedUrl: vi.fn(),
+    queryResults: [] as Array<{ data: unknown; error: unknown }>,
+}))
+
+vi.mock('../src/lib/db', () => ({
+    db: {
+        from: mockState.from,
+    },
+    Tables: {
+        WEBSITES: 'websites',
+        MEDIA_R2_CONFIGS: 'media_r2_configs',
+    },
+    COLUMNS: {
+        WEBSITE_SLUG: 'website_slug',
+    },
+}))
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+    getSignedUrl: mockState.getSignedUrl,
+}))
+
+import mediaR2Service from '../src/services/media-r2'
+
+const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
+    const builder = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        is: vi.fn(),
+        maybeSingle: vi.fn(),
+    }
+
+    builder.select.mockReturnValue(builder)
+    builder.eq.mockReturnValue(builder)
+    builder.is.mockReturnValue(builder)
+    builder.maybeSingle.mockResolvedValue(result)
+
+    return builder
+}
+
+describe('media R2 presigned upload service', () => {
+    beforeEach(() => {
+        mockState.from.mockReset()
+        mockState.getSignedUrl.mockReset()
+        mockState.queryResults = []
+        mockState.from.mockImplementation(() =>
+            makeQueryBuilder(
+                mockState.queryResults.shift() || { data: null, error: null }
+            )
+        )
+        mockState.getSignedUrl.mockResolvedValue(
+            'https://signed.example.test/upload'
+        )
+        process.env.R2_ACCESS_KEY_ID = 'test-access-key'
+        process.env.R2_SECRET_ACCESS_KEY = 'test-secret-key'
+        process.env.R2_ACCOUNT_ID = 'test-account'
+        process.env.R2_BUCKET_NAME = 'env-bucket'
+        process.env.R2_PUBLIC_BASE_URL = 'https://env-public.example.test'
+        process.env.R2_PRESIGN_EXPIRES_SECONDS = '900'
+        process.env.MEDIA_MAX_UPLOAD_BYTES = '1500000'
+    })
+
+    it('prefers website R2 config from Supabase when available', async () => {
+        mockState.queryResults = [
+            {
+                data: {
+                    id: 'website-1',
+                    client_id: 'client-1',
+                },
+                error: null,
+            },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://persisted.example.test',
+                    key_prefix: 'portfolio',
+                },
+                error: null,
+            },
+        ]
+
+        const result = await mediaR2Service.createPresignedUpload({
+            websiteSlug: 'iffers-pictures',
+            filename: 'Baby Shower.jpg',
+            contentType: 'image/jpeg',
+            folder: 'Events/Baby Shower',
+            size: 123456,
+        })
+
+        expect(mockState.from).toHaveBeenCalledWith('websites')
+        expect(mockState.from).toHaveBeenCalledWith('media_r2_configs')
+        expect(mockState.getSignedUrl).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            { expiresIn: 900 }
+        )
+        expect(result).toEqual(
+            expect.objectContaining({
+                presigned_url: 'https://signed.example.test/upload',
+                public_url: expect.stringContaining(
+                    'https://persisted.example.test/portfolio/events/baby-shower/'
+                ),
+                r2_key: expect.stringContaining(
+                    'portfolio/events/baby-shower/'
+                ),
+            })
+        )
+        expect(result.expires_at).toEqual(expect.any(String))
+    })
+
+    it('falls back to env R2 config when no persisted config exists', async () => {
+        mockState.queryResults = [
+            {
+                data: {
+                    id: 'website-1',
+                    client_id: 'client-1',
+                },
+                error: null,
+            },
+            { data: null, error: null },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaR2Service.createPresignedUpload({
+            websiteSlug: 'iffers-pictures',
+            filename: 'Portrait.png',
+            contentType: 'image/png',
+            folder: 'Portrait',
+            size: 123456,
+        })
+
+        expect(result.public_url).toContain(
+            'https://env-public.example.test/portrait/'
+        )
+        expect(result.r2_key).toContain('portrait/')
+    })
+})

--- a/test/media-r2-service.test.ts
+++ b/test/media-r2-service.test.ts
@@ -95,7 +95,10 @@ describe('media R2 presigned upload service', () => {
         expect(mockState.getSignedUrl).toHaveBeenCalledWith(
             expect.anything(),
             expect.anything(),
-            { expiresIn: 900 }
+            {
+                expiresIn: 900,
+                signableHeaders: new Set(['content-type', 'content-length']),
+            }
         )
         expect(result).toEqual(
             expect.objectContaining({

--- a/test/media-r2.test.ts
+++ b/test/media-r2.test.ts
@@ -1,0 +1,170 @@
+import { Request, Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import mediaController from '../src/controllers/media'
+import {
+    buildR2ObjectKey,
+    joinPublicUrl,
+    validateUploadInput,
+} from '../src/lib/media-r2'
+import mediaR2Service from '../src/services/media-r2'
+
+vi.mock('../src/services/media-r2', () => ({
+    default: {
+        createPresignedUpload: vi.fn(),
+    },
+}))
+
+const createResponse = () => {
+    const res = {
+        status: vi.fn(),
+        json: vi.fn(),
+    }
+    res.status.mockReturnValue(res)
+    res.json.mockReturnValue(res)
+    return res as unknown as Response & {
+        status: ReturnType<typeof vi.fn>
+        json: ReturnType<typeof vi.fn>
+    }
+}
+
+const createRequest = ({
+    params = { websiteSlug: 'iffers-pictures' },
+    body = {},
+}: {
+    params?: Record<string, string>
+    body?: unknown
+}): Request =>
+    ({
+        params,
+        body,
+    }) as unknown as Request
+
+describe('media R2 key and upload validation helpers', () => {
+    beforeEach(() => {
+        process.env.MEDIA_MAX_UPLOAD_BYTES = '1500000'
+    })
+
+    it('generates safe collision-resistant R2 keys', () => {
+        const key = buildR2ObjectKey({
+            filename: '../Baby Shower 15.JPG',
+            contentType: 'image/jpeg',
+            folder: 'Events/Baby Shower',
+            keyPrefix: '/iffers uploads/',
+            now: 1712345678000,
+            uniqueSuffix: 'abc123',
+        })
+
+        expect(key).toBe(
+            'iffers-uploads/events/baby-shower/1712345678000-abc123-baby-shower-15.jpg'
+        )
+        expect(key).not.toContain('..')
+        expect(key).not.toContain('//')
+    })
+
+    it('uses the validated content type for the stored file extension', () => {
+        const key = buildR2ObjectKey({
+            filename: 'Portrait Final.gif',
+            contentType: 'image/webp',
+            folder: 'Portrait',
+            now: 1712345678000,
+            uniqueSuffix: 'abc123',
+        })
+
+        expect(key).toBe(
+            'portrait/1712345678000-abc123-portrait-final.webp'
+        )
+    })
+
+    it('rejects invalid content types', () => {
+        expect(() =>
+            validateUploadInput({
+                contentType: 'image/gif',
+                size: 1000,
+            })
+        ).toThrow('Unsupported upload content type.')
+    })
+
+    it('rejects oversized uploads', () => {
+        expect(() =>
+            validateUploadInput({
+                contentType: 'image/jpeg',
+                size: 1500001,
+            })
+        ).toThrow('Upload exceeds the configured maximum size.')
+    })
+
+    it('joins public URLs without duplicate slashes', () => {
+        expect(joinPublicUrl('https://pub.example.test/', 'events/test.jpg')).toBe(
+            'https://pub.example.test/events/test.jpg'
+        )
+    })
+})
+
+describe('media presigned upload controller', () => {
+    beforeEach(() => {
+        vi.mocked(mediaR2Service.createPresignedUpload).mockResolvedValue({
+            presigned_url: 'https://signed.example.test/upload',
+            public_url:
+                'https://pub.example.test/events/baby-shower/1712345678000-abc123-baby.jpg',
+            r2_key: 'events/baby-shower/1712345678000-abc123-baby.jpg',
+            expires_at: '2026-05-27T12:00:00.000Z',
+        })
+    })
+
+    it('returns the presigned upload response shape', async () => {
+        const res = createResponse()
+
+        await mediaController.presignUpload(
+            createRequest({
+                body: {
+                    filename: 'Baby.jpg',
+                    content_type: 'image/jpeg',
+                    folder: 'events/baby-shower',
+                    size: 123456,
+                },
+            }),
+            res
+        )
+
+        expect(mediaR2Service.createPresignedUpload).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            filename: 'Baby.jpg',
+            contentType: 'image/jpeg',
+            folder: 'events/baby-shower',
+            size: 123456,
+        })
+        expect(res.status).toHaveBeenCalledWith(200)
+        expect(res.json).toHaveBeenCalledWith({
+            presigned_url: 'https://signed.example.test/upload',
+            public_url:
+                'https://pub.example.test/events/baby-shower/1712345678000-abc123-baby.jpg',
+            r2_key: 'events/baby-shower/1712345678000-abc123-baby.jpg',
+            expires_at: '2026-05-27T12:00:00.000Z',
+        })
+    })
+
+    it('returns a consistent error envelope for invalid payloads', async () => {
+        const res = createResponse()
+
+        await mediaController.presignUpload(
+            createRequest({
+                body: {
+                    filename: '',
+                    content_type: 'image/jpeg',
+                    size: 123456,
+                },
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.objectContaining({
+                    code: 'media.invalid_payload',
+                }),
+            })
+        )
+    })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -17,6 +17,13 @@ const externalServiceEnvKeys = [
     'MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES',
     'MEDIA_ADMIN_SESSION_TTL_HOURS',
     'MEDIA_ADMIN_REQUEST_MIN_RESPONSE_MS',
+    'R2_ACCESS_KEY_ID',
+    'R2_SECRET_ACCESS_KEY',
+    'R2_ACCOUNT_ID',
+    'R2_BUCKET_NAME',
+    'R2_PUBLIC_BASE_URL',
+    'R2_PRESIGN_EXPIRES_SECONDS',
+    'MEDIA_MAX_UPLOAD_BYTES',
 ]
 
 const buildTestEnv = (): NodeJS.ProcessEnv => {


### PR DESCRIPTION
## Summary
- Adds protected `POST /api/media/:websiteSlug/admin/uploads/presign` media upload signing endpoint.
- Adds server-only Cloudflare R2 S3-compatible presigning with `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner`.
- Resolves website by `website_slug`, prefers Supabase `media_r2_configs`, and falls back to server env R2 bucket/public URL.
- Normalizes folder and filenames into safe kebab-case R2 keys with timestamp and random suffix collision guards.
- Enforces allowed image content types and configurable max upload size before signing.

## API Contract
`POST /api/media/:websiteSlug/admin/uploads/presign`

Protected by the media admin session cookie.

Request:
```json
{
  "filename": "baby-shower-15.jpg",
  "content_type": "image/jpeg",
  "folder": "events/baby-shower",
  "size": 1234567
}
```

Response:
```json
{
  "presigned_url": "https://...",
  "public_url": "https://pub-.../events/baby-shower/1712345678-abc123-baby-shower-15.jpg",
  "r2_key": "events/baby-shower/1712345678-abc123-baby-shower-15.jpg",
  "expires_at": "2026-05-27T12:00:00.000Z"
}
```

## Environment
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_ACCOUNT_ID`
- `R2_BUCKET_NAME` fallback when no persisted config exists
- `R2_PUBLIC_BASE_URL` fallback when no persisted config exists
- `R2_PRESIGN_EXPIRES_SECONDS` optional, defaults to 900
- `MEDIA_MAX_UPLOAD_BYTES` optional, defaults to 10MB

## Validation
- `npm run build`
- `/Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run`

## Logical QA
- Confirm unauthenticated requests to the presign route return 401 from media admin auth middleware.
- Confirm invalid `content_type` returns `media.invalid_content_type`.
- Confirm `size` above `MEDIA_MAX_UPLOAD_BYTES` returns `media.file_too_large`.
- Confirm existing `media_r2_configs` values are used before env fallback.
- Confirm returned `r2_key` has safe kebab-case path segments and no raw filename/folder traversal.
- Confirm returned `presigned_url` is short-lived and works for direct PUT with the requested content type in a non-production R2 test bucket.

## QA Checklist
- [ ] Apply required R2 env vars in the target environment.
- [ ] Ensure `media_r2_configs` has the Iffer media bucket/public URL, or env fallback is intentionally configured.
- [ ] Request a presign URL as an authenticated media admin.
- [ ] PUT a JPEG/PNG/WEBP file to the returned URL.
- [ ] Verify the object appears in R2 at `r2_key` and public URL resolves.
- [ ] Verify oversized and unsupported-type requests are blocked.

## Visual QA
None. This is a server API and R2 signing contract change only.