### PR TITLE
DEV-932 Add media catalog APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `/api/media-admin/auth/callback` | POST | Exchange a one-time magic-link token for an HTTP-only media admin session cookie. | `controllers/media-admin-auth.callback` |
 | `/api/media-admin/auth/session` | GET | Return the current media admin session when the session cookie is valid. | `controllers/media-admin-auth.getSession` |
 | `/api/media-admin/auth/logout` | POST | Revoke the current media admin session and clear the cookie. | `controllers/media-admin-auth.logout` |
+| `/api/media/:websiteSlug/catalog` | GET | Fetch published media catalog items for a website. | `controllers/media.getPublicCatalog` |
+| `/api/media/:websiteSlug/admin/catalog` | GET | Fetch full media catalog for authenticated media admins. | `controllers/media.getAdminCatalog` |
+| `/api/media/:websiteSlug/admin/items` | POST | Create a draft media catalog item after upload. | `controllers/media.createCatalogItem` |
+| `/api/media/:websiteSlug/admin/items/:id` | PATCH | Update safe media catalog metadata for authenticated media admins. | `controllers/media.updateCatalogItem` |
 | `/api/media/:websiteSlug/admin/uploads/presign` | POST | Create a protected, short-lived Cloudflare R2 direct-upload URL. | `controllers/media.presignUpload` |
 
 > `routes/recaptcha.ts` is currently a placeholder; wire it before exposing any verification endpoint.

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import { z, ZodError } from 'zod'
 
+import mediaCatalogService from '../services/media-catalog'
 import mediaR2Service from '../services/media-r2'
 import { MediaValidationError } from '../lib/media-r2'
 import { handleGenericError } from '../utils/http'
@@ -11,6 +12,28 @@ const presignUploadSchema = z.object({
     folder: z.string().trim().max(500).optional(),
     size: z.number().int().positive(),
 })
+
+const nullableCatalogString = z
+    .union([z.string().trim().max(255), z.null()])
+    .optional()
+
+const createCatalogItemSchema = z.object({
+    key: z.string().trim().min(1).max(1000),
+    filename: z.string().trim().min(1).max(255).optional(),
+    src: z.string().trim().url().max(2000).optional(),
+    alt: z.string().trim().max(1000).optional(),
+    service: nullableCatalogString,
+    subCategory: nullableCatalogString,
+    aspectRatio: nullableCatalogString,
+    sortOrder: z.number().int().min(0).optional(),
+})
+
+const updateCatalogItemSchema = createCatalogItemSchema.partial().refine(
+    value => Object.keys(value).length > 0,
+    {
+        message: 'At least one field is required.',
+    }
+)
 
 const sendMediaError = (
     res: Response,
@@ -80,4 +103,182 @@ const presignUpload = async (
     }
 }
 
-export default { presignUpload }
+const getPublicCatalog = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const catalog = await mediaCatalogService.listCatalog({
+            websiteSlug: req.params.websiteSlug,
+            includeAdminFields: false,
+        })
+
+        res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=300')
+        return res.status(200).json(catalog)
+    } catch (err) {
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const getAdminCatalog = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const catalog = await mediaCatalogService.listCatalog({
+            websiteSlug: req.params.websiteSlug,
+            includeAdminFields: true,
+        })
+
+        res.set('Cache-Control', 'no-store')
+        return res.status(200).json(catalog)
+    } catch (err) {
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const createCatalogItem = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = createCatalogItemSchema.parse(req.body)
+        const item = await mediaCatalogService.createItem({
+            websiteSlug: req.params.websiteSlug,
+            key: parsed.key,
+            filename: parsed.filename,
+            src: parsed.src,
+            alt: parsed.alt,
+            service: parsed.service,
+            subCategory: parsed.subCategory,
+            aspectRatio: parsed.aspectRatio,
+            sortOrder: parsed.sortOrder,
+        })
+
+        return res.status(201).json(item)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid media catalog item payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const updateCatalogItem = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = updateCatalogItemSchema.parse(req.body)
+        const itemId = Number(req.params.id)
+        const item = await mediaCatalogService.updateItem({
+            websiteSlug: req.params.websiteSlug,
+            id: itemId,
+            key: parsed.key,
+            filename: parsed.filename,
+            src: parsed.src,
+            alt: parsed.alt,
+            service: parsed.service,
+            subCategory: parsed.subCategory,
+            aspectRatio: parsed.aspectRatio,
+            sortOrder: parsed.sortOrder,
+        })
+
+        return res.status(200).json(item)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid media catalog item payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+export default {
+    presignUpload,
+    getPublicCatalog,
+    getAdminCatalog,
+    createCatalogItem,
+    updateCatalogItem,
+}

--- a/src/lib/media-catalog.ts
+++ b/src/lib/media-catalog.ts
@@ -1,0 +1,135 @@
+import { MediaValidationError } from './media-r2'
+
+export const MEDIA_CATALOG_VERSION = 1
+
+export const MEDIA_STATUSES = ['draft', 'published', 'archived'] as const
+export type MediaStatus = (typeof MEDIA_STATUSES)[number]
+
+export const MEDIA_ASPECT_RATIOS = [
+    'portrait',
+    'landscape',
+    'square',
+    'video',
+] as const
+export type MediaAspectRatio = (typeof MEDIA_ASPECT_RATIOS)[number]
+
+export const MEDIA_SERVICES = [
+    'Events',
+    'Family',
+    'Maternity',
+    'Couples',
+    'Portrait',
+] as const
+export type MediaService = (typeof MEDIA_SERVICES)[number]
+
+export const MEDIA_SUB_CATEGORIES: Record<MediaService, string[]> = {
+    Events: [
+        'Baby Shower',
+        'Bridal Shower',
+        'Gender Reveal',
+        'Birthday',
+        'Baptism',
+    ],
+    Family: ['Family'],
+    Maternity: ['Maternity'],
+    Couples: ['Engagement', 'Proposal'],
+    Portrait: ['Portrait'],
+}
+
+export const isMediaService = (value: unknown): value is MediaService =>
+    typeof value === 'string' && MEDIA_SERVICES.includes(value as MediaService)
+
+export const isMediaAspectRatio = (
+    value: unknown
+): value is MediaAspectRatio =>
+    typeof value === 'string' &&
+    MEDIA_ASPECT_RATIOS.includes(value as MediaAspectRatio)
+
+export const assertValidServiceSubCategory = ({
+    service,
+    subCategory,
+}: {
+    service?: string | null
+    subCategory?: string | null
+}): void => {
+    if (service && !isMediaService(service)) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_service',
+            'Invalid media service.',
+            { field: 'service', allowed: MEDIA_SERVICES }
+        )
+    }
+
+    if (!subCategory) return
+
+    if (!service) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_sub_category',
+            'Sub-category requires a valid service.',
+            { field: 'subCategory' }
+        )
+    }
+
+    const allowed = MEDIA_SUB_CATEGORIES[service as MediaService] || []
+    if (!allowed.includes(subCategory)) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_sub_category',
+            'Invalid media sub-category for service.',
+            { field: 'subCategory', service, allowed }
+        )
+    }
+}
+
+export const assertValidAspectRatio = (
+    aspectRatio?: string | null
+): void => {
+    if (!aspectRatio) return
+
+    if (!isMediaAspectRatio(aspectRatio)) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_aspect_ratio',
+            'Invalid media aspect ratio.',
+            { field: 'aspectRatio', allowed: MEDIA_ASPECT_RATIOS }
+        )
+    }
+}
+
+export const assertSafeMediaKey = (key: string): void => {
+    if (
+        key !== key.toLowerCase() ||
+        key.startsWith('/') ||
+        key.endsWith('/') ||
+        key.includes('//') ||
+        key.includes('..')
+    ) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_key',
+            'Media key must be a safe lowercase R2 object key.',
+            { field: 'key' }
+        )
+    }
+}
+
+export const assertSafeFilename = (filename: string): void => {
+    if (
+        filename !== filename.toLowerCase() ||
+        filename.includes('/') ||
+        filename.includes('\\') ||
+        filename.includes('..')
+    ) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_filename',
+            'Filename must be safe and lowercase.',
+            { field: 'filename' }
+        )
+    }
+}
+
+export const filenameFromKey = (key: string): string =>
+    key.split('/').filter(Boolean).pop() || key

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -7,6 +7,33 @@ import { requireMediaAdminSession, validateRequest } from './middleware'
 const router: Router = Router()
 const BASE_ROUTE = '/api/media'
 
+router.get(
+    `${BASE_ROUTE}/:websiteSlug/catalog`,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+    ],
+    validateRequest,
+    media.getPublicCatalog
+)
+
+router.get(
+    `${BASE_ROUTE}/:websiteSlug/admin/catalog`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+    ],
+    validateRequest,
+    media.getAdminCatalog
+)
+
 router.post(
     `${BASE_ROUTE}/:websiteSlug/admin/uploads/presign`,
     requireMediaAdminSession,
@@ -36,6 +63,102 @@ router.post(
     ],
     validateRequest,
     media.presignUpload
+)
+
+router.post(
+    `${BASE_ROUTE}/:websiteSlug/admin/items`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        body('key').isString().trim().notEmpty().withMessage('key is required'),
+        body('filename')
+            .optional()
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('filename must be a non-empty string'),
+        body('src')
+            .optional()
+            .isURL({ require_protocol: true })
+            .withMessage('src must be a valid URL'),
+        body('alt')
+            .optional()
+            .isString()
+            .withMessage('alt must be a string'),
+        body('service')
+            .optional({ nullable: true })
+            .isString()
+            .withMessage('service must be a string'),
+        body('subCategory')
+            .optional({ nullable: true })
+            .isString()
+            .withMessage('subCategory must be a string'),
+        body('aspectRatio')
+            .optional({ nullable: true })
+            .isString()
+            .withMessage('aspectRatio must be a string'),
+        body('sortOrder')
+            .optional()
+            .isInt({ min: 0 })
+            .withMessage('sortOrder must be a non-negative integer'),
+    ],
+    validateRequest,
+    media.createCatalogItem
+)
+
+router.patch(
+    `${BASE_ROUTE}/:websiteSlug/admin/items/:id`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        param('id').isInt({ min: 1 }).withMessage('id must be a positive integer'),
+        body('key')
+            .optional()
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('key must be a non-empty string'),
+        body('filename')
+            .optional()
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('filename must be a non-empty string'),
+        body('src')
+            .optional()
+            .isURL({ require_protocol: true })
+            .withMessage('src must be a valid URL'),
+        body('alt')
+            .optional()
+            .isString()
+            .withMessage('alt must be a string'),
+        body('service')
+            .optional({ nullable: true })
+            .isString()
+            .withMessage('service must be a string'),
+        body('subCategory')
+            .optional({ nullable: true })
+            .isString()
+            .withMessage('subCategory must be a string'),
+        body('aspectRatio')
+            .optional({ nullable: true })
+            .isString()
+            .withMessage('aspectRatio must be a string'),
+        body('sortOrder')
+            .optional()
+            .isInt({ min: 0 })
+            .withMessage('sortOrder must be a non-negative integer'),
+    ],
+    validateRequest,
+    media.updateCatalogItem
 )
 
 export default router

--- a/src/services/media-catalog.ts
+++ b/src/services/media-catalog.ts
@@ -1,0 +1,440 @@
+import { COLUMNS, db, Tables } from '../lib/db'
+import {
+    assertSafeFilename,
+    assertSafeMediaKey,
+    assertValidAspectRatio,
+    assertValidServiceSubCategory,
+    filenameFromKey,
+    MEDIA_CATALOG_VERSION,
+    MediaAspectRatio,
+    MediaService,
+    MediaStatus,
+} from '../lib/media-catalog'
+import { joinPublicUrl, MediaValidationError } from '../lib/media-r2'
+
+interface WebsiteRecord {
+    id: string
+    client_id: string
+}
+
+interface R2ConfigRecord {
+    bucket: string
+    public_base_url: string
+    key_prefix: string | null
+}
+
+interface ResolvedR2Config {
+    bucket: string
+    publicBaseUrl: string
+}
+
+export interface MediaCatalogRecord {
+    id: number
+    website_id: string
+    client_id: string
+    key: string
+    filename: string
+    src: string
+    alt: string
+    service: MediaService | null
+    sub_category: string | null
+    aspect_ratio: MediaAspectRatio | null
+    status: MediaStatus
+    sort_order: number
+    created_at: string
+    updated_at: string
+    archived_at: string | null
+    archived_by: string | null
+    archived_from_status: Exclude<MediaStatus, 'archived'> | null
+}
+
+export interface CatalogItemResponse {
+    id: number
+    key: string
+    filename: string
+    src: string
+    alt: string
+    service: MediaService | null
+    subCategory: string | null
+    aspectRatio: MediaAspectRatio | null
+    status: MediaStatus
+    sortOrder: number
+    createdAt?: string
+    updatedAt?: string
+    archivedAt?: string | null
+    archivedBy?: string | null
+    archivedFromStatus?: Exclude<MediaStatus, 'archived'> | null
+}
+
+export interface CatalogResponse {
+    version: 1
+    publicBaseUrl: string
+    bucket: string
+    items: CatalogItemResponse[]
+}
+
+export interface CreateMediaItemInput {
+    websiteSlug: string
+    key: string
+    filename?: string
+    src?: string
+    alt?: string
+    service?: string | null
+    subCategory?: string | null
+    aspectRatio?: string | null
+    sortOrder?: number
+}
+
+export interface UpdateMediaItemInput {
+    websiteSlug: string
+    id: number
+    key?: string
+    filename?: string
+    src?: string
+    alt?: string
+    service?: string | null
+    subCategory?: string | null
+    aspectRatio?: string | null
+    sortOrder?: number
+}
+
+const getWebsiteBySlug = async (
+    websiteSlug: string
+): Promise<WebsiteRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.WEBSITES)
+        .select('id, client_id')
+        .eq(COLUMNS.WEBSITE_SLUG, websiteSlug)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as WebsiteRecord | null
+}
+
+const getWebsiteOrThrow = async (websiteSlug: string): Promise<WebsiteRecord> => {
+    const website = await getWebsiteBySlug(websiteSlug)
+    if (!website) {
+        const err = new Error('Website not found') as Error & { status?: number }
+        err.status = 404
+        throw err
+    }
+
+    return website
+}
+
+const getWebsiteR2Config = async (
+    website: WebsiteRecord
+): Promise<R2ConfigRecord | null> => {
+    const { data: websiteConfig, error: websiteError } = await db
+        .from(Tables.MEDIA_R2_CONFIGS)
+        .select('bucket, public_base_url, key_prefix')
+        .eq('website_id', website.id)
+        .maybeSingle()
+
+    if (websiteError) throw websiteError
+    if (websiteConfig) return websiteConfig as R2ConfigRecord
+
+    const { data: clientConfig, error: clientError } = await db
+        .from(Tables.MEDIA_R2_CONFIGS)
+        .select('bucket, public_base_url, key_prefix')
+        .eq('client_id', website.client_id)
+        .is('website_id', null)
+        .maybeSingle()
+
+    if (clientError) throw clientError
+    return clientConfig as R2ConfigRecord | null
+}
+
+const resolveR2Config = async (
+    website: WebsiteRecord
+): Promise<ResolvedR2Config> => {
+    const persistedConfig = await getWebsiteR2Config(website)
+    const bucket = persistedConfig?.bucket || process.env.R2_BUCKET_NAME
+    const publicBaseUrl =
+        persistedConfig?.public_base_url || process.env.R2_PUBLIC_BASE_URL
+
+    if (!bucket || !publicBaseUrl) {
+        const err = new Error('R2 media configuration is not available') as Error & {
+            status?: number
+        }
+        err.status = 503
+        throw err
+    }
+
+    return { bucket, publicBaseUrl }
+}
+
+const toCatalogItemResponse = (
+    item: MediaCatalogRecord,
+    includeAdminFields: boolean
+): CatalogItemResponse => ({
+    id: item.id,
+    key: item.key,
+    filename: item.filename,
+    src: item.src,
+    alt: item.alt,
+    service: item.service,
+    subCategory: item.sub_category,
+    aspectRatio: item.aspect_ratio,
+    status: item.status,
+    sortOrder: item.sort_order,
+    ...(includeAdminFields && {
+        createdAt: item.created_at,
+        updatedAt: item.updated_at,
+        archivedAt: item.archived_at,
+        archivedBy: item.archived_by,
+        archivedFromStatus: item.archived_from_status,
+    }),
+})
+
+const buildCatalogResponse = ({
+    config,
+    records,
+    includeAdminFields,
+}: {
+    config: ResolvedR2Config
+    records: MediaCatalogRecord[]
+    includeAdminFields: boolean
+}): CatalogResponse => ({
+    version: MEDIA_CATALOG_VERSION,
+    publicBaseUrl: config.publicBaseUrl,
+    bucket: config.bucket,
+    items: records.map(item => toCatalogItemResponse(item, includeAdminFields)),
+})
+
+const listCatalog = async ({
+    websiteSlug,
+    includeAdminFields,
+}: {
+    websiteSlug: string
+    includeAdminFields: boolean
+}): Promise<CatalogResponse> => {
+    const website = await getWebsiteOrThrow(websiteSlug)
+    const config = await resolveR2Config(website)
+    const query = db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('*')
+        .eq('website_id', website.id)
+        .order('service', { ascending: true, nullsFirst: false })
+        .order('sub_category', { ascending: true, nullsFirst: false })
+        .order('sort_order', { ascending: true })
+        .order('id', { ascending: true })
+
+    if (!includeAdminFields) {
+        query.eq('status', 'published')
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+
+    return buildCatalogResponse({
+        config,
+        records: (data || []) as MediaCatalogRecord[],
+        includeAdminFields,
+    })
+}
+
+const assertNoDuplicateKey = async ({
+    websiteId,
+    key,
+    excludeId,
+}: {
+    websiteId: string
+    key: string
+    excludeId?: number
+}): Promise<void> => {
+    let query = db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('id')
+        .eq('website_id', websiteId)
+        .eq('key', key)
+
+    if (excludeId) {
+        query = query.neq('id', excludeId)
+    }
+
+    const { data, error } = await query.maybeSingle()
+    if (error) throw error
+
+    if (data) throwDuplicateKeyError(key)
+}
+
+const isUniqueViolation = (error: unknown): boolean =>
+    typeof (error as { code?: unknown })?.code === 'string' &&
+    (error as { code: string }).code === '23505'
+
+const throwDuplicateKeyError = (key: string): never => {
+    throw new MediaValidationError(
+        409,
+        'media.duplicate_key',
+        'A media catalog item already exists for this key.',
+        { field: 'key', key }
+    )
+}
+
+const buildValidatedDraftPayload = async ({
+    website,
+    config,
+    input,
+}: {
+    website: WebsiteRecord
+    config: ResolvedR2Config
+    input: CreateMediaItemInput
+}): Promise<Record<string, unknown>> => {
+    assertSafeMediaKey(input.key)
+
+    const filename = input.filename || filenameFromKey(input.key)
+    assertSafeFilename(filename)
+    assertValidServiceSubCategory({
+        service: input.service,
+        subCategory: input.subCategory,
+    })
+    assertValidAspectRatio(input.aspectRatio)
+    await assertNoDuplicateKey({ websiteId: website.id, key: input.key })
+
+    return {
+        website_id: website.id,
+        client_id: website.client_id,
+        key: input.key,
+        filename,
+        src: input.src || joinPublicUrl(config.publicBaseUrl, input.key),
+        alt: input.alt || '',
+        service: input.service || null,
+        sub_category: input.subCategory || null,
+        aspect_ratio: input.aspectRatio || null,
+        status: 'draft',
+        sort_order: input.sortOrder ?? 0,
+    }
+}
+
+const createItem = async (
+    input: CreateMediaItemInput
+): Promise<CatalogItemResponse> => {
+    const website = await getWebsiteOrThrow(input.websiteSlug)
+    const config = await resolveR2Config(website)
+    const payload = await buildValidatedDraftPayload({ website, config, input })
+
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .insert(payload)
+        .select('*')
+        .single()
+
+    if (error) {
+        if (isUniqueViolation(error)) throwDuplicateKeyError(input.key)
+        throw error
+    }
+    return toCatalogItemResponse(data as MediaCatalogRecord, true)
+}
+
+const getItemForWebsite = async ({
+    websiteId,
+    id,
+}: {
+    websiteId: string
+    id: number
+}): Promise<MediaCatalogRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .eq('id', id)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as MediaCatalogRecord | null
+}
+
+const updateItem = async (
+    input: UpdateMediaItemInput
+): Promise<CatalogItemResponse> => {
+    const website = await getWebsiteOrThrow(input.websiteSlug)
+    const config = await resolveR2Config(website)
+    const current = await getItemForWebsite({ websiteId: website.id, id: input.id })
+
+    if (!current) {
+        const err = new Error('Media catalog item not found') as Error & {
+            status?: number
+        }
+        err.status = 404
+        throw err
+    }
+
+    if (
+        current.status === 'published' &&
+        ((input.key !== undefined && input.key !== current.key) ||
+            (input.src !== undefined && input.src !== current.src))
+    ) {
+        throw new MediaValidationError(
+            409,
+            'media.published_location_locked',
+            'Published media object locations cannot be changed by metadata patch.',
+            { fields: ['key', 'src'], status: current.status }
+        )
+    }
+
+    const nextKey = input.key ?? current.key
+    const nextFilename =
+        input.filename ?? (input.key ? filenameFromKey(input.key) : current.filename)
+    const nextService =
+        input.service === undefined ? current.service : input.service
+    const nextSubCategory =
+        input.subCategory === undefined
+            ? current.sub_category
+            : input.subCategory
+    const nextAspectRatio =
+        input.aspectRatio === undefined
+            ? current.aspect_ratio
+            : input.aspectRatio
+
+    assertSafeMediaKey(nextKey)
+    assertSafeFilename(nextFilename)
+    assertValidServiceSubCategory({
+        service: nextService,
+        subCategory: nextSubCategory,
+    })
+    assertValidAspectRatio(nextAspectRatio)
+
+    if (nextKey !== current.key) {
+        await assertNoDuplicateKey({
+            websiteId: website.id,
+            key: nextKey,
+            excludeId: input.id,
+        })
+    }
+
+    const patch: Record<string, unknown> = {
+        key: nextKey,
+        filename: nextFilename,
+        src:
+            input.src ??
+            (nextKey !== current.key
+                ? joinPublicUrl(config.publicBaseUrl, nextKey)
+                : current.src),
+        alt: input.alt ?? current.alt,
+        service: nextService || null,
+        sub_category: nextSubCategory || null,
+        aspect_ratio: nextAspectRatio || null,
+        sort_order: input.sortOrder ?? current.sort_order,
+    }
+
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .update(patch)
+        .eq('website_id', website.id)
+        .eq('id', input.id)
+        .select('*')
+        .single()
+
+    if (error) {
+        if (isUniqueViolation(error)) throwDuplicateKeyError(nextKey)
+        throw error
+    }
+    return toCatalogItemResponse(data as MediaCatalogRecord, true)
+}
+
+export default {
+    listCatalog,
+    createItem,
+    updateItem,
+}

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+    from: vi.fn(),
+    queryResults: [] as Array<{ data: unknown; error: unknown }>,
+    builders: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+}))
+
+vi.mock('../src/lib/db', () => ({
+    db: {
+        from: mockState.from,
+    },
+    Tables: {
+        WEBSITES: 'websites',
+        MEDIA_R2_CONFIGS: 'media_r2_configs',
+        MEDIA_CATALOG_ITEMS: 'media_catalog_items',
+    },
+    COLUMNS: {
+        WEBSITE_SLUG: 'website_slug',
+    },
+}))
+
+import mediaCatalogService from '../src/services/media-catalog'
+
+const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
+    const builder = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        is: vi.fn(),
+        neq: vi.fn(),
+        order: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        maybeSingle: vi.fn(),
+        single: vi.fn(),
+        then: vi.fn(),
+    }
+
+    builder.select.mockReturnValue(builder)
+    builder.eq.mockReturnValue(builder)
+    builder.is.mockReturnValue(builder)
+    builder.neq.mockReturnValue(builder)
+    builder.order.mockReturnValue(builder)
+    builder.insert.mockReturnValue(builder)
+    builder.update.mockReturnValue(builder)
+    builder.maybeSingle.mockResolvedValue(result)
+    builder.single.mockResolvedValue(result)
+    builder.then.mockImplementation((resolve, reject) =>
+        Promise.resolve(result).then(resolve, reject)
+    )
+
+    return builder
+}
+
+const publishedItem = {
+    id: 1,
+    website_id: 'website-1',
+    client_id: 'client-1',
+    key: 'events/baby-shower/baby.jpg',
+    filename: 'baby.jpg',
+    src: 'https://pub.example.test/events/baby-shower/baby.jpg',
+    alt: 'Mother-to-be opening gifts',
+    service: 'Events',
+    sub_category: 'Baby Shower',
+    aspect_ratio: 'portrait',
+    status: 'published',
+    sort_order: 0,
+    created_at: '2026-05-27T12:00:00.000Z',
+    updated_at: '2026-05-27T12:30:00.000Z',
+    archived_at: null,
+    archived_by: null,
+    archived_from_status: null,
+}
+
+const archivedItem = {
+    ...publishedItem,
+    id: 2,
+    key: 'events/baby-shower/archived.jpg',
+    filename: 'archived.jpg',
+    src: 'https://pub.example.test/events/baby-shower/archived.jpg',
+    status: 'archived',
+    archived_at: '2026-05-28T12:00:00.000Z',
+    archived_by: 'admin@example.test',
+    archived_from_status: 'published',
+}
+
+describe('media catalog service', () => {
+    beforeEach(() => {
+        mockState.from.mockReset()
+        mockState.queryResults = []
+        mockState.builders = []
+        mockState.from.mockImplementation(() => {
+            const builder = makeQueryBuilder(
+                mockState.queryResults.shift() || {
+                    data: null,
+                    error: null,
+                }
+            )
+            mockState.builders.push(builder)
+            return builder
+        })
+        process.env.R2_BUCKET_NAME = 'iffers-pictures'
+        process.env.R2_PUBLIC_BASE_URL = 'https://env-pub.example.test'
+    })
+
+    it('returns only published catalog items for the public catalog', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: [publishedItem], error: null },
+        ]
+
+        const catalog = await mediaCatalogService.listCatalog({
+            websiteSlug: 'iffers-pictures',
+            includeAdminFields: false,
+        })
+
+        expect(catalog).toEqual({
+            version: 1,
+            publicBaseUrl: 'https://pub.example.test',
+            bucket: 'persisted-bucket',
+            items: [
+                {
+                    id: 1,
+                    key: 'events/baby-shower/baby.jpg',
+                    filename: 'baby.jpg',
+                    src: 'https://pub.example.test/events/baby-shower/baby.jpg',
+                    alt: 'Mother-to-be opening gifts',
+                    service: 'Events',
+                    subCategory: 'Baby Shower',
+                    aspectRatio: 'portrait',
+                    status: 'published',
+                    sortOrder: 0,
+                },
+            ],
+        })
+        expect(mockState.builders[2].eq).toHaveBeenCalledWith(
+            'status',
+            'published'
+        )
+        expect(catalog.items[0]).not.toHaveProperty('archivedAt')
+    })
+
+    it('returns all catalog items with archive metadata for the admin catalog', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: [publishedItem, archivedItem], error: null },
+        ]
+
+        const catalog = await mediaCatalogService.listCatalog({
+            websiteSlug: 'iffers-pictures',
+            includeAdminFields: true,
+        })
+
+        expect(catalog.items).toHaveLength(2)
+        expect(mockState.builders[2].eq).not.toHaveBeenCalledWith(
+            'status',
+            'published'
+        )
+        expect(catalog.items[1]).toEqual(
+            expect.objectContaining({
+                id: 2,
+                status: 'archived',
+                archivedAt: '2026-05-28T12:00:00.000Z',
+                archivedBy: 'admin@example.test',
+                archivedFromStatus: 'published',
+            })
+        )
+    })
+
+    it('creates draft catalog items and derives src from R2 config', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: null, error: null },
+            {
+                data: {
+                    ...publishedItem,
+                    status: 'draft',
+                    key: 'portrait/new-image.jpg',
+                    filename: 'new-image.jpg',
+                    src: 'https://pub.example.test/portrait/new-image.jpg',
+                    alt: '',
+                    service: null,
+                    sub_category: null,
+                    aspect_ratio: null,
+                    sort_order: 0,
+                },
+                error: null,
+            },
+        ]
+
+        const item = await mediaCatalogService.createItem({
+            websiteSlug: 'iffers-pictures',
+            key: 'portrait/new-image.jpg',
+        })
+
+        expect(mockState.builders[3].insert).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            key: 'portrait/new-image.jpg',
+            filename: 'new-image.jpg',
+            src: 'https://pub.example.test/portrait/new-image.jpg',
+            alt: '',
+            service: null,
+            sub_category: null,
+            aspect_ratio: null,
+            status: 'draft',
+            sort_order: 0,
+        })
+        expect(item).toEqual(
+            expect.objectContaining({
+                key: 'portrait/new-image.jpg',
+                status: 'draft',
+                createdAt: '2026-05-27T12:00:00.000Z',
+            })
+        )
+    })
+
+    it('returns a conflict when a catalog key already exists', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: { id: 10 }, error: null },
+        ]
+
+        await expect(
+            mediaCatalogService.createItem({
+                websiteSlug: 'iffers-pictures',
+                key: 'events/baby-shower/baby.jpg',
+                filename: 'baby.jpg',
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.duplicate_key',
+        })
+    })
+
+    it('blocks direct key changes on published catalog items', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: publishedItem, error: null },
+        ]
+
+        await expect(
+            mediaCatalogService.updateItem({
+                websiteSlug: 'iffers-pictures',
+                id: 1,
+                key: 'events/baby-shower/moved.jpg',
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.published_location_locked',
+        })
+    })
+})

--- a/test/media-r2.test.ts
+++ b/test/media-r2.test.ts
@@ -15,6 +15,14 @@ vi.mock('../src/services/media-r2', () => ({
     },
 }))
 
+vi.mock('../src/services/media-catalog', () => ({
+    default: {
+        listCatalog: vi.fn(),
+        createItem: vi.fn(),
+        updateItem: vi.fn(),
+    },
+}))
+
 const createResponse = () => {
     const res = {
         status: vi.fn(),


### PR DESCRIPTION
## Summary
- Add public and admin media catalog endpoints under /api/media/:websiteSlug.
- Add Supabase-backed media catalog service with public published-only output, admin full-catalog output, draft item creation, safe metadata patching, duplicate key conflicts, and published location lockouts.
- Add media catalog validation helpers and focused Vitest coverage for public/admin filtering, response mapping, draft defaults, duplicate keys, and published key safety.

## Risks / follow-up
- Publish/archive/restore lifecycle rules remain for DEV-933.
- R2 object move/rename operations remain for DEV-934.
- Audit logging remains for DEV-936.
- Frontend-facing API documentation remains for DEV-938.

## Visual QA
None: backend API-only change.

## Logical QA
- Confirm GET /api/media/:websiteSlug/catalog returns only published items and does not include archive metadata.
- Confirm GET /api/media/:websiteSlug/admin/catalog requires a valid media admin session and returns draft, published, and archived rows with archive metadata.
- Confirm POST /api/media/:websiteSlug/admin/items creates draft records and rejects duplicate keys with media.duplicate_key.
- Confirm PATCH /api/media/:websiteSlug/admin/items/:id updates metadata and blocks direct key/src changes for published media.

## Verification
- npm run build
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run