### PR TITLE
DEV-933 Enforce media lifecycle validation

### DIFF
--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -28,12 +28,14 @@ const createCatalogItemSchema = z.object({
     sortOrder: z.number().int().min(0).optional(),
 })
 
-const updateCatalogItemSchema = createCatalogItemSchema.partial().refine(
-    value => Object.keys(value).length > 0,
-    {
+const updateCatalogItemSchema = createCatalogItemSchema
+    .partial()
+    .extend({
+        status: z.string().trim().max(50).optional(),
+    })
+    .refine(value => Object.keys(value).length > 0, {
         message: 'At least one field is required.',
-    }
-)
+    })
 
 const sendMediaError = (
     res: Response,
@@ -235,6 +237,8 @@ const updateCatalogItem = async (
             subCategory: parsed.subCategory,
             aspectRatio: parsed.aspectRatio,
             sortOrder: parsed.sortOrder,
+            status: parsed.status,
+            actor: req.mediaAdmin?.email,
         })
 
         return res.status(200).json(item)

--- a/src/lib/media-catalog.ts
+++ b/src/lib/media-catalog.ts
@@ -45,6 +45,9 @@ export const isMediaAspectRatio = (
     typeof value === 'string' &&
     MEDIA_ASPECT_RATIOS.includes(value as MediaAspectRatio)
 
+export const isMediaStatus = (value: unknown): value is MediaStatus =>
+    typeof value === 'string' && MEDIA_STATUSES.includes(value as MediaStatus)
+
 export const assertValidServiceSubCategory = ({
     service,
     subCategory,
@@ -94,6 +97,19 @@ export const assertValidAspectRatio = (
             'media.invalid_aspect_ratio',
             'Invalid media aspect ratio.',
             { field: 'aspectRatio', allowed: MEDIA_ASPECT_RATIOS }
+        )
+    }
+}
+
+export const assertValidStatus = (status?: string | null): void => {
+    if (!status) return
+
+    if (!isMediaStatus(status)) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_status',
+            'Invalid media status.',
+            { field: 'status', allowed: MEDIA_STATUSES }
         )
     }
 }

--- a/src/lib/media-catalog.ts
+++ b/src/lib/media-catalog.ts
@@ -102,7 +102,7 @@ export const assertValidAspectRatio = (
 }
 
 export const assertValidStatus = (status?: string | null): void => {
-    if (!status) return
+    if (status === undefined || status === null) return
 
     if (!isMediaStatus(status)) {
         throw new MediaValidationError(

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -152,6 +152,10 @@ router.patch(
             .optional({ nullable: true })
             .isString()
             .withMessage('aspectRatio must be a string'),
+        body('status')
+            .optional()
+            .isString()
+            .withMessage('status must be a string'),
         body('sortOrder')
             .optional()
             .isInt({ min: 0 })

--- a/src/services/media-catalog.ts
+++ b/src/services/media-catalog.ts
@@ -4,6 +4,7 @@ import {
     assertSafeMediaKey,
     assertValidAspectRatio,
     assertValidServiceSubCategory,
+    assertValidStatus,
     filenameFromKey,
     MEDIA_CATALOG_VERSION,
     MediaAspectRatio,
@@ -96,6 +97,8 @@ export interface UpdateMediaItemInput {
     subCategory?: string | null
     aspectRatio?: string | null
     sortOrder?: number
+    status?: string
+    actor?: string
 }
 
 const getWebsiteBySlug = async (
@@ -272,6 +275,54 @@ const throwDuplicateKeyError = (key: string): never => {
     )
 }
 
+const assertPublishReady = ({
+    alt,
+    service,
+    subCategory,
+    aspectRatio,
+}: {
+    alt?: string | null
+    service?: string | null
+    subCategory?: string | null
+    aspectRatio?: string | null
+}): void => {
+    if (!alt?.trim()) {
+        throw new MediaValidationError(
+            400,
+            'media.missing_alt_text',
+            'Alt text is required before publishing media.',
+            { field: 'alt' }
+        )
+    }
+
+    if (!service) {
+        throw new MediaValidationError(
+            400,
+            'media.missing_service',
+            'Service is required before publishing media.',
+            { field: 'service' }
+        )
+    }
+
+    if (!subCategory) {
+        throw new MediaValidationError(
+            400,
+            'media.missing_sub_category',
+            'Sub-category is required before publishing media.',
+            { field: 'subCategory' }
+        )
+    }
+
+    if (!aspectRatio) {
+        throw new MediaValidationError(
+            400,
+            'media.missing_aspect_ratio',
+            'Aspect ratio is required before publishing media.',
+            { field: 'aspectRatio' }
+        )
+    }
+}
+
 const buildValidatedDraftPayload = async ({
     website,
     config,
@@ -363,13 +414,49 @@ const updateItem = async (
     if (
         current.status === 'published' &&
         ((input.key !== undefined && input.key !== current.key) ||
-            (input.src !== undefined && input.src !== current.src))
+            (input.src !== undefined && input.src !== current.src) ||
+            (input.filename !== undefined && input.filename !== current.filename))
     ) {
         throw new MediaValidationError(
             409,
             'media.published_location_locked',
-            'Published media object locations cannot be changed by metadata patch.',
-            { fields: ['key', 'src'], status: current.status }
+            'Published media object locations and filenames cannot be changed by metadata patch.',
+            { fields: ['key', 'src', 'filename'], status: current.status }
+        )
+    }
+
+    assertValidStatus(input.status)
+
+    const requestedStatus = input.status as MediaStatus | undefined
+    const isArchivedRestore =
+        current.status === 'archived' &&
+        requestedStatus !== undefined &&
+        requestedStatus !== 'archived'
+    const includesMetadataEdit =
+        input.key !== undefined ||
+        input.filename !== undefined ||
+        input.src !== undefined ||
+        input.alt !== undefined ||
+        input.service !== undefined ||
+        input.subCategory !== undefined ||
+        input.aspectRatio !== undefined ||
+        input.sortOrder !== undefined
+
+    if (current.status === 'archived' && !isArchivedRestore) {
+        throw new MediaValidationError(
+            409,
+            'media.archived_locked',
+            'Archived media cannot be edited until restored.',
+            { status: current.status }
+        )
+    }
+
+    if (isArchivedRestore && includesMetadataEdit) {
+        throw new MediaValidationError(
+            409,
+            'media.archived_locked',
+            'Restore archived media before editing metadata.',
+            { status: current.status }
         )
     }
 
@@ -386,6 +473,10 @@ const updateItem = async (
         input.aspectRatio === undefined
             ? current.aspect_ratio
             : input.aspectRatio
+    const nextStatus =
+        isArchivedRestore && current.archived_from_status
+            ? current.archived_from_status
+            : ((input.status ?? current.status) as MediaStatus)
 
     assertSafeMediaKey(nextKey)
     assertSafeFilename(nextFilename)
@@ -416,6 +507,41 @@ const updateItem = async (
         sub_category: nextSubCategory || null,
         aspect_ratio: nextAspectRatio || null,
         sort_order: input.sortOrder ?? current.sort_order,
+    }
+
+    if (nextStatus === 'published') {
+        assertPublishReady({
+            alt: patch.alt as string | null,
+            service: patch.service as string | null,
+            subCategory: patch.sub_category as string | null,
+            aspectRatio: patch.aspect_ratio as string | null,
+        })
+    }
+
+    if (nextStatus === 'archived') {
+        if (current.status === 'archived') {
+            throw new MediaValidationError(
+                409,
+                'media.invalid_status_transition',
+                'Media is already archived.',
+                { from: current.status, to: nextStatus }
+            )
+        }
+
+        patch.status = 'archived'
+        patch.archived_at = new Date().toISOString()
+        patch.archived_by = input.actor || null
+        patch.archived_from_status = current.status
+    } else if (current.status === 'archived') {
+        patch.status = nextStatus
+        patch.archived_at = null
+        patch.archived_by = null
+        patch.archived_from_status = null
+    } else if (nextStatus !== current.status) {
+        patch.status = nextStatus
+        patch.archived_at = null
+        patch.archived_by = null
+        patch.archived_from_status = null
     }
 
     const { data, error } = await db

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -84,6 +84,19 @@ const archivedItem = {
     archived_from_status: 'published',
 }
 
+const draftItem = {
+    ...publishedItem,
+    id: 3,
+    key: 'portrait/draft.jpg',
+    filename: 'draft.jpg',
+    src: 'https://pub.example.test/portrait/draft.jpg',
+    alt: '',
+    service: null,
+    sub_category: null,
+    aspect_ratio: null,
+    status: 'draft',
+}
+
 describe('media catalog service', () => {
     beforeEach(() => {
         mockState.from.mockReset()
@@ -288,6 +301,184 @@ describe('media catalog service', () => {
         ).rejects.toMatchObject({
             status: 409,
             code: 'media.published_location_locked',
+        })
+    })
+
+    it('rejects invalid service and sub-category pairings', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+        ]
+
+        await expect(
+            mediaCatalogService.createItem({
+                websiteSlug: 'iffers-pictures',
+                key: 'events/baby-shower/wrong.jpg',
+                service: 'Family',
+                subCategory: 'Baby Shower',
+            })
+        ).rejects.toMatchObject({
+            status: 400,
+            code: 'media.invalid_sub_category',
+        })
+    })
+
+    it('blocks publishing when required public metadata is missing', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: draftItem, error: null },
+        ]
+
+        await expect(
+            mediaCatalogService.updateItem({
+                websiteSlug: 'iffers-pictures',
+                id: 3,
+                status: 'published',
+                service: 'Portrait',
+                subCategory: 'Portrait',
+                aspectRatio: 'portrait',
+            })
+        ).rejects.toMatchObject({
+            status: 400,
+            code: 'media.missing_alt_text',
+        })
+    })
+
+    it('archives media and preserves archive metadata', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: publishedItem, error: null },
+            {
+                data: {
+                    ...publishedItem,
+                    status: 'archived',
+                    archived_at: '2026-05-28T01:00:00.000Z',
+                    archived_by: 'jenn@example.com',
+                    archived_from_status: 'published',
+                },
+                error: null,
+            },
+        ]
+
+        const item = await mediaCatalogService.updateItem({
+            websiteSlug: 'iffers-pictures',
+            id: 1,
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.builders[3].update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: 'archived',
+                archived_at: expect.any(String),
+                archived_by: 'jenn@example.com',
+                archived_from_status: 'published',
+            })
+        )
+        expect(item).toEqual(
+            expect.objectContaining({
+                status: 'archived',
+                archivedBy: 'jenn@example.com',
+                archivedFromStatus: 'published',
+            })
+        )
+    })
+
+    it('restores archived media to its previous status and clears archive metadata', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: archivedItem, error: null },
+            {
+                data: {
+                    ...archivedItem,
+                    status: 'published',
+                    archived_at: null,
+                    archived_by: null,
+                    archived_from_status: null,
+                },
+                error: null,
+            },
+        ]
+
+        const item = await mediaCatalogService.updateItem({
+            websiteSlug: 'iffers-pictures',
+            id: 2,
+            status: 'draft',
+        })
+
+        expect(mockState.builders[3].update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: 'published',
+                archived_at: null,
+                archived_by: null,
+                archived_from_status: null,
+            })
+        )
+        expect(item).toEqual(
+            expect.objectContaining({
+                status: 'published',
+                archivedAt: null,
+                archivedBy: null,
+                archivedFromStatus: null,
+            })
+        )
+    })
+
+    it('blocks metadata edits while media is archived', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: archivedItem, error: null },
+        ]
+
+        await expect(
+            mediaCatalogService.updateItem({
+                websiteSlug: 'iffers-pictures',
+                id: 2,
+                status: 'published',
+                alt: 'Updated alt text',
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.archived_locked',
         })
     })
 })

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -417,6 +417,33 @@ describe('media catalog service', () => {
         )
     })
 
+    it('rejects blank status values before transition handling', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: draftItem, error: null },
+        ]
+
+        await expect(
+            mediaCatalogService.updateItem({
+                websiteSlug: 'iffers-pictures',
+                id: 3,
+                status: '',
+            })
+        ).rejects.toMatchObject({
+            status: 400,
+            code: 'media.invalid_status',
+        })
+        expect(mockState.builders).toHaveLength(3)
+    })
+
     it('archives media and preserves archive metadata', async () => {
         mockState.queryResults = [
             { data: { id: 'website-1', client_id: 'client-1' }, error: null },

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -359,6 +359,64 @@ describe('media catalog service', () => {
         })
     })
 
+    it('publishes a draft when required public metadata is present', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: draftItem, error: null },
+            {
+                data: {
+                    ...draftItem,
+                    alt: 'Jenn photographing a portrait session',
+                    service: 'Portrait',
+                    sub_category: 'Portrait',
+                    aspect_ratio: 'portrait',
+                    status: 'published',
+                },
+                error: null,
+            },
+        ]
+
+        const item = await mediaCatalogService.updateItem({
+            websiteSlug: 'iffers-pictures',
+            id: 3,
+            status: 'published',
+            alt: 'Jenn photographing a portrait session',
+            service: 'Portrait',
+            subCategory: 'Portrait',
+            aspectRatio: 'portrait',
+        })
+
+        expect(mockState.builders[3].update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                alt: 'Jenn photographing a portrait session',
+                service: 'Portrait',
+                sub_category: 'Portrait',
+                aspect_ratio: 'portrait',
+                status: 'published',
+                archived_at: null,
+                archived_by: null,
+                archived_from_status: null,
+            })
+        )
+        expect(item).toEqual(
+            expect.objectContaining({
+                status: 'published',
+                alt: 'Jenn photographing a portrait session',
+                service: 'Portrait',
+                subCategory: 'Portrait',
+                aspectRatio: 'portrait',
+            })
+        )
+    })
+
     it('archives media and preserves archive metadata', async () => {
         mockState.queryResults = [
             { data: { id: 'website-1', client_id: 'client-1' }, error: null },


### PR DESCRIPTION
## Summary
- Extend admin media item patching with an optional status field for publish, archive, and restore transitions.
- Enforce service/sub-category, aspect ratio, status, publish readiness, archived edit locks, and published location/filename locks in the media catalog service.
- Preserve archive metadata on archive and restore archived records to their previous draft/published status when available.
- Add focused service tests for invalid categories, missing publish metadata, archive/restore transitions, and invalid archived/published transitions.

## Contract notes
- PATCH /api/media/:websiteSlug/admin/items/:id now accepts optional status: draft | published | archived.
- Archived records must be restored with a status change before metadata edits are allowed.
- Published records cannot change key, src, or filename through the generic metadata patch endpoint.

## Risks / follow-up
- R2 object move/rename remains for DEV-934 and should provide the explicit safe flow for published locations.
- Audit logging remains for DEV-936.
- Cache revalidation remains for DEV-937.

## Visual QA
None: backend API-only change.

## Logical QA
- Attempt to publish a draft without alt text and confirm media.missing_alt_text.
- Publish a fully populated draft and confirm the item becomes published.
- Archive a draft and published item and confirm archived_at, archived_by, and archived_from_status are preserved.
- Restore an archived item and confirm it returns to the previous draft/published status where archived_from_status exists.
- Attempt metadata edits while archived and confirm media.archived_locked.
- Attempt key/src/filename changes while published and confirm media.published_location_locked.

## QA checklist
- Verify PATCH status=published rejects missing alt/service/subCategory/aspectRatio.
- Verify invalid service/subCategory combinations return media.invalid_sub_category.
- Verify invalid aspectRatio/status values return media.invalid_aspect_ratio or media.invalid_status.
- Verify archive preserves actor email from the media admin session.
- Verify restore clears archive metadata.

## Verification
- npm run build
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run test/media-catalog.test.ts
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run