### PR TITLE
DEV-934 Add safe R2 object operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,10 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `/api/media-admin/auth/logout` | POST | Revoke the current media admin session and clear the cookie. | `controllers/media-admin-auth.logout` |
 | `/api/media/:websiteSlug/catalog` | GET | Fetch published media catalog items for a website. | `controllers/media.getPublicCatalog` |
 | `/api/media/:websiteSlug/admin/catalog` | GET | Fetch full media catalog for authenticated media admins. | `controllers/media.getAdminCatalog` |
+| `/api/media/:websiteSlug/admin/objects` | GET | List Cloudflare R2 objects by optional prefix for authenticated media admins. | `controllers/media.listObjects` |
+| `/api/media/:websiteSlug/admin/objects/check-destination` | POST | Check catalog and R2 destination collisions before moving media. | `controllers/media.checkDestination` |
 | `/api/media/:websiteSlug/admin/items` | POST | Create a draft media catalog item after upload. | `controllers/media.createCatalogItem` |
+| `/api/media/:websiteSlug/admin/items/:id/move` | POST | Safely move/rename a draft R2 object and update its catalog record. | `controllers/media.moveCatalogItem` |
 | `/api/media/:websiteSlug/admin/items/:id` | PATCH | Update safe media catalog metadata for authenticated media admins. | `controllers/media.updateCatalogItem` |
 | `/api/media/:websiteSlug/admin/uploads/presign` | POST | Create a protected, short-lived Cloudflare R2 direct-upload URL. | `controllers/media.presignUpload` |
 

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -13,6 +13,15 @@ const presignUploadSchema = z.object({
     size: z.number().int().positive(),
 })
 
+const checkDestinationSchema = z.object({
+    destination_key: z.string().trim().min(1).max(1000),
+    exclude_media_id: z.number().int().positive().optional(),
+})
+
+const moveCatalogItemSchema = z.object({
+    destination_key: z.string().trim().min(1).max(1000),
+})
+
 const nullableCatalogString = z
     .union([z.string().trim().max(255), z.null()])
     .optional()
@@ -97,6 +106,145 @@ const presignUpload = async (
                 status === 404
                     ? 'media.website_not_found'
                     : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const listObjects = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const prefix =
+            typeof req.query.prefix === 'string' ? req.query.prefix : undefined
+        const result = await mediaR2Service.listObjects({
+            websiteSlug: req.params.websiteSlug,
+            prefix,
+        })
+
+        res.set('Cache-Control', 'no-store')
+        return res.status(200).json(result)
+    } catch (err) {
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const checkDestination = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = checkDestinationSchema.parse(req.body)
+        const result = await mediaR2Service.checkDestination({
+            websiteSlug: req.params.websiteSlug,
+            destinationKey: parsed.destination_key,
+            excludeMediaId: parsed.exclude_media_id,
+        })
+
+        return res.status(200).json(result)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid destination check payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const moveCatalogItem = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = moveCatalogItemSchema.parse(req.body)
+        const result = await mediaR2Service.moveCatalogItemObject({
+            websiteSlug: req.params.websiteSlug,
+            id: Number(req.params.id),
+            destinationKey: parsed.destination_key,
+        })
+
+        return res.status(200).json(result)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid media move payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404 ? 'media.not_found' : 'media.r2_not_configured'
 
             return sendMediaError(res, status, code, message)
         }
@@ -281,6 +429,9 @@ const updateCatalogItem = async (
 
 export default {
     presignUpload,
+    listObjects,
+    checkDestination,
+    moveCatalogItem,
     getPublicCatalog,
     getAdminCatalog,
     createCatalogItem,

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -34,6 +34,43 @@ router.get(
     media.getAdminCatalog
 )
 
+router.get(
+    `${BASE_ROUTE}/:websiteSlug/admin/objects`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+    ],
+    validateRequest,
+    media.listObjects
+)
+
+router.post(
+    `${BASE_ROUTE}/:websiteSlug/admin/objects/check-destination`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        body('destination_key')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('destination_key is required'),
+        body('exclude_media_id')
+            .optional()
+            .isInt({ min: 1 })
+            .withMessage('exclude_media_id must be a positive integer'),
+    ],
+    validateRequest,
+    media.checkDestination
+)
+
 router.post(
     `${BASE_ROUTE}/:websiteSlug/admin/uploads/presign`,
     requireMediaAdminSession,
@@ -108,6 +145,26 @@ router.post(
     ],
     validateRequest,
     media.createCatalogItem
+)
+
+router.post(
+    `${BASE_ROUTE}/:websiteSlug/admin/items/:id/move`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        param('id').isInt({ min: 1 }).withMessage('id must be a positive integer'),
+        body('destination_key')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('destination_key is required'),
+    ],
+    validateRequest,
+    media.moveCatalogItem
 )
 
 router.patch(

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -1,13 +1,30 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import {
+    CopyObjectCommand,
+    DeleteObjectCommand,
+    HeadObjectCommand,
+    ListObjectsV2Command,
+    PutObjectCommand,
+    S3Client,
+} from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 
 import { COLUMNS, db, Tables } from '../lib/db'
+import {
+    assertSafeFilename,
+    assertSafeMediaKey,
+    filenameFromKey,
+} from '../lib/media-catalog'
 import {
     buildR2ObjectKey,
     joinPublicUrl,
     presignExpiresSeconds,
     validateUploadInput,
+    MediaValidationError,
 } from '../lib/media-r2'
+import mediaCatalogService, {
+    CatalogItemResponse,
+    MediaCatalogRecord,
+} from './media-catalog'
 
 export interface PresignUploadInput {
     websiteSlug: string
@@ -22,6 +39,51 @@ export interface PresignUploadResult {
     public_url: string
     r2_key: string
     expires_at: string
+}
+
+export interface R2ObjectSummary {
+    key: string
+    public_url: string
+    size: number
+    last_modified?: string
+    etag?: string
+}
+
+export interface ListObjectsInput {
+    websiteSlug: string
+    prefix?: string
+}
+
+export interface ListObjectsResult {
+    bucket: string
+    prefix: string
+    objects: R2ObjectSummary[]
+}
+
+export interface CheckDestinationInput {
+    websiteSlug: string
+    destinationKey: string
+    excludeMediaId?: number
+}
+
+export interface CheckDestinationResult {
+    destination_key: string
+    catalog_exists: boolean
+    r2_exists: boolean
+    available: boolean
+}
+
+export interface MoveCatalogItemInput {
+    websiteSlug: string
+    id: number
+    destinationKey: string
+}
+
+export interface MoveCatalogItemResult {
+    item: CatalogItemResponse
+    source_key: string
+    destination_key: string
+    source_deleted: boolean
 }
 
 interface WebsiteRecord {
@@ -39,6 +101,10 @@ interface ResolvedR2Config {
     bucket: string
     publicBaseUrl: string
     keyPrefix: string
+}
+
+interface CatalogKeyRecord {
+    id: number
 }
 
 const getWebsiteBySlug = async (
@@ -121,6 +187,141 @@ const createR2Client = (): S3Client => {
     })
 }
 
+const normalizePrefix = (prefix?: string): string => {
+    if (!prefix) return ''
+    const normalized = prefix.trim().replace(/^\/+|\/+$/g, '')
+    if (!normalized) return ''
+
+    assertSafeMediaKey(normalized)
+    return normalized
+}
+
+const assertDestinationKey = (key: string): void => {
+    assertSafeMediaKey(key)
+    assertSafeFilename(filenameFromKey(key))
+}
+
+const catalogKeyExists = async ({
+    websiteId,
+    key,
+    excludeMediaId,
+}: {
+    websiteId: string
+    key: string
+    excludeMediaId?: number
+}): Promise<boolean> => {
+    let query = db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('id')
+        .eq('website_id', websiteId)
+        .eq('key', key)
+
+    if (excludeMediaId) {
+        query = query.neq('id', excludeMediaId)
+    }
+
+    const { data, error } = await query.maybeSingle()
+    if (error) throw error
+
+    return Boolean(data as CatalogKeyRecord | null)
+}
+
+const getCatalogItem = async ({
+    websiteId,
+    id,
+}: {
+    websiteId: string
+    id: number
+}): Promise<MediaCatalogRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .eq('id', id)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as MediaCatalogRecord | null
+}
+
+const objectExists = async ({
+    client,
+    bucket,
+    key,
+}: {
+    client: S3Client
+    bucket: string
+    key: string
+}): Promise<boolean> => {
+    try {
+        await client.send(
+            new HeadObjectCommand({
+                Bucket: bucket,
+                Key: key,
+            })
+        )
+        return true
+    } catch (err) {
+        const statusCode = (err as { $metadata?: { httpStatusCode?: number } })
+            ?.$metadata?.httpStatusCode
+        const name = (err as { name?: string })?.name
+
+        if (statusCode === 404 || name === 'NotFound' || name === 'NoSuchKey') {
+            return false
+        }
+
+        throw err
+    }
+}
+
+const assertDestinationAvailable = async ({
+    websiteId,
+    client,
+    config,
+    destinationKey,
+    excludeMediaId,
+}: {
+    websiteId: string
+    client: S3Client
+    config: ResolvedR2Config
+    destinationKey: string
+    excludeMediaId?: number
+}): Promise<CheckDestinationResult> => {
+    const catalogExists = await catalogKeyExists({
+        websiteId,
+        key: destinationKey,
+        excludeMediaId,
+    })
+    const r2Exists = await objectExists({
+        client,
+        bucket: config.bucket,
+        key: destinationKey,
+    })
+
+    const result = {
+        destination_key: destinationKey,
+        catalog_exists: catalogExists,
+        r2_exists: r2Exists,
+        available: !catalogExists && !r2Exists,
+    }
+
+    if (!result.available) {
+        throw new MediaValidationError(
+            409,
+            'media.destination_collision',
+            'An image already exists at that destination.',
+            {
+                field: 'destination_key',
+                key: destinationKey,
+                catalog_exists: catalogExists,
+                r2_exists: r2Exists,
+            }
+        )
+    }
+
+    return result
+}
+
 const createPresignedUpload = async ({
     websiteSlug,
     filename,
@@ -166,6 +367,195 @@ const createPresignedUpload = async ({
     }
 }
 
+const listObjects = async ({
+    websiteSlug,
+    prefix,
+}: ListObjectsInput): Promise<ListObjectsResult> => {
+    const website = await getWebsiteBySlug(websiteSlug)
+    if (!website) {
+        const err = new Error('Website not found') as Error & { status?: number }
+        err.status = 404
+        throw err
+    }
+
+    const config = await resolveR2Config(website)
+    const normalizedPrefix = normalizePrefix(prefix)
+    const client = createR2Client()
+    const { Contents, IsTruncated } = await client.send(
+        new ListObjectsV2Command({
+            Bucket: config.bucket,
+            Prefix: normalizedPrefix || undefined,
+            MaxKeys: 1000,
+        })
+    )
+
+    if (IsTruncated) {
+        console.warn(
+            `R2 object listing truncated for ${websiteSlug} prefix "${normalizedPrefix}"`
+        )
+    }
+
+    return {
+        bucket: config.bucket,
+        prefix: normalizedPrefix,
+        objects: (Contents || [])
+            .filter(object => Boolean(object.Key))
+            .map(object => ({
+                key: object.Key as string,
+                public_url: joinPublicUrl(config.publicBaseUrl, object.Key as string),
+                size: object.Size || 0,
+                last_modified: object.LastModified?.toISOString(),
+                etag: object.ETag?.replace(/^"|"$/g, ''),
+            })),
+    }
+}
+
+const checkDestination = async ({
+    websiteSlug,
+    destinationKey,
+    excludeMediaId,
+}: CheckDestinationInput): Promise<CheckDestinationResult> => {
+    const website = await getWebsiteBySlug(websiteSlug)
+    if (!website) {
+        const err = new Error('Website not found') as Error & { status?: number }
+        err.status = 404
+        throw err
+    }
+
+    assertDestinationKey(destinationKey)
+    const config = await resolveR2Config(website)
+    const client = createR2Client()
+    const catalogExists = await catalogKeyExists({
+        websiteId: website.id,
+        key: destinationKey,
+        excludeMediaId,
+    })
+    const r2Exists = await objectExists({
+        client,
+        bucket: config.bucket,
+        key: destinationKey,
+    })
+
+    return {
+        destination_key: destinationKey,
+        catalog_exists: catalogExists,
+        r2_exists: r2Exists,
+        available: !catalogExists && !r2Exists,
+    }
+}
+
+const moveCatalogItemObject = async ({
+    websiteSlug,
+    id,
+    destinationKey,
+}: MoveCatalogItemInput): Promise<MoveCatalogItemResult> => {
+    const website = await getWebsiteBySlug(websiteSlug)
+    if (!website) {
+        const err = new Error('Website not found') as Error & { status?: number }
+        err.status = 404
+        throw err
+    }
+
+    assertDestinationKey(destinationKey)
+    const config = await resolveR2Config(website)
+    const item = await getCatalogItem({ websiteId: website.id, id })
+
+    if (!item) {
+        const err = new Error('Media catalog item not found') as Error & {
+            status?: number
+        }
+        err.status = 404
+        throw err
+    }
+
+    if (item.status === 'published') {
+        throw new MediaValidationError(
+            409,
+            'media.published_location_locked',
+            'Published media cannot be moved without an explicit safe flow.',
+            { status: item.status }
+        )
+    }
+
+    if (item.status === 'archived') {
+        throw new MediaValidationError(
+            409,
+            'media.archived_locked',
+            'Archived media cannot be moved until restored.',
+            { status: item.status }
+        )
+    }
+
+    if (item.key === destinationKey) {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_destination',
+            'Destination key must be different from the current key.',
+            { field: 'destination_key', key: destinationKey }
+        )
+    }
+
+    const client = createR2Client()
+    const sourceExists = await objectExists({
+        client,
+        bucket: config.bucket,
+        key: item.key,
+    })
+
+    if (!sourceExists) {
+        throw new MediaValidationError(
+            404,
+            'media.source_not_found',
+            'The source R2 object does not exist.',
+            { key: item.key }
+        )
+    }
+
+    await assertDestinationAvailable({
+        websiteId: website.id,
+        client,
+        config,
+        destinationKey,
+        excludeMediaId: id,
+    })
+
+    await client.send(
+        new CopyObjectCommand({
+            Bucket: config.bucket,
+            Key: destinationKey,
+            CopySource: `${config.bucket}/${encodeURIComponent(item.key).replace(
+                /%2F/g,
+                '/'
+            )}`,
+        })
+    )
+
+    const updatedItem = await mediaCatalogService.updateItem({
+        websiteSlug,
+        id,
+        key: destinationKey,
+        filename: filenameFromKey(destinationKey),
+        src: joinPublicUrl(config.publicBaseUrl, destinationKey),
+    })
+
+    await client.send(
+        new DeleteObjectCommand({
+            Bucket: config.bucket,
+            Key: item.key,
+        })
+    )
+
+    return {
+        item: updatedItem,
+        source_key: item.key,
+        destination_key: destinationKey,
+        source_deleted: true,
+    }
+}
+
 export default {
     createPresignedUpload,
+    listObjects,
+    checkDestination,
+    moveCatalogItemObject,
 }

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -214,6 +214,19 @@ const scopedObjectKey = ({
     return `${keyPrefix}/${normalizedKey}`
 }
 
+const isKeyInConfiguredPrefix = ({
+    key,
+    config,
+}: {
+    key: string
+    config: ResolvedR2Config
+}): boolean => {
+    const keyPrefix = normalizePrefix(config.keyPrefix)
+    if (!keyPrefix) return true
+
+    return key === keyPrefix || key.startsWith(`${keyPrefix}/`)
+}
+
 const assertKeyInConfiguredPrefix = ({
     key,
     config,
@@ -224,7 +237,7 @@ const assertKeyInConfiguredPrefix = ({
     const keyPrefix = normalizePrefix(config.keyPrefix)
     if (!keyPrefix) return
 
-    if (key !== keyPrefix && !key.startsWith(`${keyPrefix}/`)) {
+    if (!isKeyInConfiguredPrefix({ key, config })) {
         throw new MediaValidationError(
             409,
             'media.key_prefix_mismatch',
@@ -446,9 +459,12 @@ const listObjects = async ({
     }
 
     const config = await resolveR2Config(website)
+    const keyPrefix = normalizePrefix(config.keyPrefix)
     const normalizedPrefix = prefix
         ? scopedObjectKey({ key: prefix, config })
-        : normalizePrefix(config.keyPrefix)
+        : keyPrefix
+          ? `${keyPrefix}/`
+          : ''
     const client = createR2Client()
     const { Contents, IsTruncated } = await client.send(
         new ListObjectsV2Command({
@@ -469,6 +485,12 @@ const listObjects = async ({
         prefix: normalizedPrefix,
         objects: (Contents || [])
             .filter(object => Boolean(object.Key))
+            .filter(object =>
+                isKeyInConfiguredPrefix({
+                    key: object.Key as string,
+                    config,
+                })
+            )
             .map(object => ({
                 key: object.Key as string,
                 public_url: joinPublicUrl(config.publicBaseUrl, object.Key as string),
@@ -648,18 +670,27 @@ const moveCatalogItemObject = async ({
         throw err
     }
 
-    await client.send(
-        new DeleteObjectCommand({
-            Bucket: config.bucket,
-            Key: item.key,
-        })
-    )
+    let sourceDeleted = true
+    try {
+        await client.send(
+            new DeleteObjectCommand({
+                Bucket: config.bucket,
+                Key: item.key,
+            })
+        )
+    } catch (err) {
+        sourceDeleted = false
+        console.error(
+            `Failed to delete source R2 object after catalog move: ${item.key}`,
+            err
+        )
+    }
 
     return {
         item: updatedItem,
         source_key: item.key,
         destination_key: scopedDestinationKey,
-        source_deleted: true,
+        source_deleted: sourceDeleted,
     }
 }
 

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -196,6 +196,44 @@ const normalizePrefix = (prefix?: string): string => {
     return normalized
 }
 
+const scopedObjectKey = ({
+    key,
+    config,
+}: {
+    key: string
+    config: ResolvedR2Config
+}): string => {
+    const normalizedKey = normalizePrefix(key)
+    const keyPrefix = normalizePrefix(config.keyPrefix)
+
+    if (!keyPrefix) return normalizedKey
+    if (normalizedKey === keyPrefix || normalizedKey.startsWith(`${keyPrefix}/`)) {
+        return normalizedKey
+    }
+
+    return `${keyPrefix}/${normalizedKey}`
+}
+
+const assertKeyInConfiguredPrefix = ({
+    key,
+    config,
+}: {
+    key: string
+    config: ResolvedR2Config
+}): void => {
+    const keyPrefix = normalizePrefix(config.keyPrefix)
+    if (!keyPrefix) return
+
+    if (key !== keyPrefix && !key.startsWith(`${keyPrefix}/`)) {
+        throw new MediaValidationError(
+            409,
+            'media.key_prefix_mismatch',
+            'Media object key is outside the configured R2 prefix.',
+            { field: 'key', key, key_prefix: keyPrefix }
+        )
+    }
+}
+
 const assertDestinationKey = (key: string): void => {
     assertSafeMediaKey(key)
     assertSafeFilename(filenameFromKey(key))
@@ -408,7 +446,9 @@ const listObjects = async ({
     }
 
     const config = await resolveR2Config(website)
-    const normalizedPrefix = normalizePrefix(prefix)
+    const normalizedPrefix = prefix
+        ? scopedObjectKey({ key: prefix, config })
+        : normalizePrefix(config.keyPrefix)
     const client = createR2Client()
     const { Contents, IsTruncated } = await client.send(
         new ListObjectsV2Command({
@@ -451,22 +491,26 @@ const checkDestination = async ({
         throw err
     }
 
-    assertDestinationKey(destinationKey)
     const config = await resolveR2Config(website)
+    const scopedDestinationKey = scopedObjectKey({
+        key: destinationKey,
+        config,
+    })
+    assertDestinationKey(scopedDestinationKey)
     const client = createR2Client()
     const catalogExists = await catalogKeyExists({
         websiteId: website.id,
-        key: destinationKey,
+        key: scopedDestinationKey,
         excludeMediaId,
     })
     const r2Exists = await objectExists({
         client,
         bucket: config.bucket,
-        key: destinationKey,
+        key: scopedDestinationKey,
     })
 
     return {
-        destination_key: destinationKey,
+        destination_key: scopedDestinationKey,
         catalog_exists: catalogExists,
         r2_exists: r2Exists,
         available: !catalogExists && !r2Exists,
@@ -485,8 +529,12 @@ const moveCatalogItemObject = async ({
         throw err
     }
 
-    assertDestinationKey(destinationKey)
     const config = await resolveR2Config(website)
+    const scopedDestinationKey = scopedObjectKey({
+        key: destinationKey,
+        config,
+    })
+    assertDestinationKey(scopedDestinationKey)
     const item = await getCatalogItem({ websiteId: website.id, id })
 
     if (!item) {
@@ -515,12 +563,14 @@ const moveCatalogItemObject = async ({
         )
     }
 
-    if (item.key === destinationKey) {
+    assertKeyInConfiguredPrefix({ key: item.key, config })
+
+    if (item.key === scopedDestinationKey) {
         throw new MediaValidationError(
             400,
             'media.invalid_destination',
             'Destination key must be different from the current key.',
-            { field: 'destination_key', key: destinationKey }
+            { field: 'destination_key', key: scopedDestinationKey }
         )
     }
 
@@ -544,7 +594,7 @@ const moveCatalogItemObject = async ({
         websiteId: website.id,
         client,
         config,
-        destinationKey,
+        destinationKey: scopedDestinationKey,
         excludeMediaId: id,
     })
 
@@ -552,7 +602,7 @@ const moveCatalogItemObject = async ({
         await client.send(
             new CopyObjectCommand({
                 Bucket: config.bucket,
-                Key: destinationKey,
+                Key: scopedDestinationKey,
                 CopySource: `${config.bucket}/${encodeURIComponent(
                     item.key
                 ).replace(/%2F/g, '/')}`,
@@ -562,7 +612,7 @@ const moveCatalogItemObject = async ({
     } catch (err) {
         if (isConditionalWriteFailure(err)) {
             throwDestinationCollision({
-                destinationKey,
+                destinationKey: scopedDestinationKey,
                 catalogExists: false,
                 r2Exists: true,
             })
@@ -571,13 +621,32 @@ const moveCatalogItemObject = async ({
         throw err
     }
 
-    const updatedItem = await mediaCatalogService.updateItem({
-        websiteSlug,
-        id,
-        key: destinationKey,
-        filename: filenameFromKey(destinationKey),
-        src: joinPublicUrl(config.publicBaseUrl, destinationKey),
-    })
+    let updatedItem: CatalogItemResponse
+    try {
+        updatedItem = await mediaCatalogService.updateItem({
+            websiteSlug,
+            id,
+            key: scopedDestinationKey,
+            filename: filenameFromKey(scopedDestinationKey),
+            src: joinPublicUrl(config.publicBaseUrl, scopedDestinationKey),
+        })
+    } catch (err) {
+        try {
+            await client.send(
+                new DeleteObjectCommand({
+                    Bucket: config.bucket,
+                    Key: scopedDestinationKey,
+                })
+            )
+        } catch (cleanupErr) {
+            console.error(
+                `Failed to clean up copied R2 object after catalog update failure: ${scopedDestinationKey}`,
+                cleanupErr
+            )
+        }
+
+        throw err
+    }
 
     await client.send(
         new DeleteObjectCommand({
@@ -589,7 +658,7 @@ const moveCatalogItemObject = async ({
     return {
         item: updatedItem,
         source_key: item.key,
-        destination_key: destinationKey,
+        destination_key: scopedDestinationKey,
         source_deleted: true,
     }
 }

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -274,6 +274,41 @@ const objectExists = async ({
     }
 }
 
+const isConditionalWriteFailure = (err: unknown): boolean => {
+    const statusCode = (err as { $metadata?: { httpStatusCode?: number } })
+        ?.$metadata?.httpStatusCode
+    const name = (err as { name?: string })?.name
+
+    return (
+        statusCode === 409 ||
+        statusCode === 412 ||
+        name === 'ConditionalRequestConflict' ||
+        name === 'PreconditionFailed'
+    )
+}
+
+const throwDestinationCollision = ({
+    destinationKey,
+    catalogExists,
+    r2Exists,
+}: {
+    destinationKey: string
+    catalogExists: boolean
+    r2Exists: boolean
+}): never => {
+    throw new MediaValidationError(
+        409,
+        'media.destination_collision',
+        'An image already exists at that destination.',
+        {
+            field: 'destination_key',
+            key: destinationKey,
+            catalog_exists: catalogExists,
+            r2_exists: r2Exists,
+        }
+    )
+}
+
 const assertDestinationAvailable = async ({
     websiteId,
     client,
@@ -306,17 +341,11 @@ const assertDestinationAvailable = async ({
     }
 
     if (!result.available) {
-        throw new MediaValidationError(
-            409,
-            'media.destination_collision',
-            'An image already exists at that destination.',
-            {
-                field: 'destination_key',
-                key: destinationKey,
-                catalog_exists: catalogExists,
-                r2_exists: r2Exists,
-            }
-        )
+        throwDestinationCollision({
+            destinationKey,
+            catalogExists,
+            r2Exists,
+        })
     }
 
     return result
@@ -519,16 +548,28 @@ const moveCatalogItemObject = async ({
         excludeMediaId: id,
     })
 
-    await client.send(
-        new CopyObjectCommand({
-            Bucket: config.bucket,
-            Key: destinationKey,
-            CopySource: `${config.bucket}/${encodeURIComponent(item.key).replace(
-                /%2F/g,
-                '/'
-            )}`,
-        })
-    )
+    try {
+        await client.send(
+            new CopyObjectCommand({
+                Bucket: config.bucket,
+                Key: destinationKey,
+                CopySource: `${config.bucket}/${encodeURIComponent(
+                    item.key
+                ).replace(/%2F/g, '/')}`,
+                IfNoneMatch: '*',
+            })
+        )
+    } catch (err) {
+        if (isConditionalWriteFailure(err)) {
+            throwDestinationCollision({
+                destinationKey,
+                catalogExists: false,
+                r2Exists: true,
+            })
+        }
+
+        throw err
+    }
 
     const updatedItem = await mediaCatalogService.updateItem({
         websiteSlug,

--- a/test/media-r2-objects.test.ts
+++ b/test/media-r2-objects.test.ts
@@ -311,6 +311,43 @@ describe('media R2 object operations', () => {
         })
     })
 
+    it('does not return adjacent R2 prefixes when listing a configured namespace root', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: prefixedR2ConfigRecord, error: null },
+        ]
+        mockState.send.mockResolvedValueOnce({
+            Contents: [
+                {
+                    Key: 'clients/iffers-pictures/events/baby-shower/image.jpg',
+                    Size: 1234,
+                },
+                {
+                    Key: 'clients/iffers-pictures-old/events/private.jpg',
+                    Size: 9999,
+                },
+            ],
+        })
+
+        const result = await mediaR2Service.listObjects({
+            websiteSlug: 'iffers-pictures',
+        })
+
+        expect(mockState.commands[0]).toEqual({
+            name: 'ListObjectsV2Command',
+            input: {
+                Bucket: 'iffers-pictures',
+                Prefix: 'clients/iffers-pictures/',
+                MaxKeys: 1000,
+            },
+        })
+        expect(result.objects).toEqual([
+            expect.objectContaining({
+                key: 'clients/iffers-pictures/events/baby-shower/image.jpg',
+            }),
+        ])
+    })
+
     it('returns catalog destination collisions without overwriting objects', async () => {
         mockState.queryResults = [
             { data: websiteRecord, error: null },
@@ -505,5 +542,55 @@ describe('media R2 object operations', () => {
                 },
             },
         ])
+    })
+
+    it('returns a partial-success move result when source object deletion fails after catalog update', async () => {
+        const deleteError = new Error('delete failed')
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined)
+
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: draftItem, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(notFoundError)
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(deleteError)
+        mockState.updateItem.mockResolvedValue({
+            id: 10,
+            key: 'events/baby-shower/delete-failed.jpg',
+            filename: 'delete-failed.jpg',
+            src: 'https://pub.example.test/events/baby-shower/delete-failed.jpg',
+            alt: 'Source image',
+            service: 'Events',
+            subCategory: 'Baby Shower',
+            aspectRatio: 'portrait',
+            status: 'draft',
+            sortOrder: 0,
+        })
+
+        try {
+            await expect(
+                mediaR2Service.moveCatalogItemObject({
+                    websiteSlug: 'iffers-pictures',
+                    id: 10,
+                    destinationKey: 'events/baby-shower/delete-failed.jpg',
+                })
+            ).resolves.toMatchObject({
+                destination_key: 'events/baby-shower/delete-failed.jpg',
+                source_deleted: false,
+            })
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Failed to delete source R2 object after catalog move: events/baby-shower/source.jpg',
+                deleteError
+            )
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 })

--- a/test/media-r2-objects.test.ts
+++ b/test/media-r2-objects.test.ts
@@ -278,6 +278,7 @@ describe('media R2 object operations', () => {
                 Bucket: 'iffers-pictures',
                 Key: 'events/baby-shower/new-name.jpg',
                 CopySource: 'iffers-pictures/events/baby-shower/source.jpg',
+                IfNoneMatch: '*',
             },
         })
         expect(mockState.updateItem).toHaveBeenCalledWith({
@@ -325,5 +326,43 @@ describe('media R2 object operations', () => {
             code: 'media.published_location_locked',
         })
         expect(mockState.send).not.toHaveBeenCalled()
+    })
+
+    it('maps conditional copy failures to destination collisions without updating catalog or deleting source', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: draftItem, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(notFoundError)
+            .mockRejectedValueOnce(
+                Object.assign(new Error('precondition failed'), {
+                    name: 'PreconditionFailed',
+                    $metadata: { httpStatusCode: 412 },
+                })
+            )
+
+        await expect(
+            mediaR2Service.moveCatalogItemObject({
+                websiteSlug: 'iffers-pictures',
+                id: 10,
+                destinationKey: 'events/baby-shower/race.jpg',
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.destination_collision',
+            details: expect.objectContaining({
+                r2_exists: true,
+            }),
+        })
+        expect(mockState.updateItem).not.toHaveBeenCalled()
+        expect(
+            mockState.commands.some(
+                command => command.name === 'DeleteObjectCommand'
+            )
+        ).toBe(false)
     })
 })

--- a/test/media-r2-objects.test.ts
+++ b/test/media-r2-objects.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+    from: vi.fn(),
+    send: vi.fn(),
+    queryResults: [] as Array<{ data: unknown; error: unknown }>,
+    builders: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+    commands: [] as Array<{ name: string; input: Record<string, unknown> }>,
+    updateItem: vi.fn(),
+}))
+
+vi.mock('../src/lib/db', () => ({
+    db: {
+        from: mockState.from,
+    },
+    Tables: {
+        WEBSITES: 'websites',
+        MEDIA_R2_CONFIGS: 'media_r2_configs',
+        MEDIA_CATALOG_ITEMS: 'media_catalog_items',
+    },
+    COLUMNS: {
+        WEBSITE_SLUG: 'website_slug',
+    },
+}))
+
+vi.mock('../src/services/media-catalog', () => ({
+    default: {
+        updateItem: mockState.updateItem,
+    },
+}))
+
+vi.mock('@aws-sdk/client-s3', () => {
+    class MockS3Client {
+        send = mockState.send
+    }
+
+    const makeCommand =
+        (name: string) =>
+        class {
+            input: Record<string, unknown>
+
+            constructor(input: Record<string, unknown>) {
+                this.input = input
+                mockState.commands.push({ name, input })
+            }
+        }
+
+    return {
+        S3Client: MockS3Client,
+        PutObjectCommand: makeCommand('PutObjectCommand'),
+        ListObjectsV2Command: makeCommand('ListObjectsV2Command'),
+        HeadObjectCommand: makeCommand('HeadObjectCommand'),
+        CopyObjectCommand: makeCommand('CopyObjectCommand'),
+        DeleteObjectCommand: makeCommand('DeleteObjectCommand'),
+    }
+})
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+    getSignedUrl: vi.fn(),
+}))
+
+import mediaR2Service from '../src/services/media-r2'
+
+const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
+    const builder = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        is: vi.fn(),
+        neq: vi.fn(),
+        maybeSingle: vi.fn(),
+        update: vi.fn(),
+        single: vi.fn(),
+    }
+
+    builder.select.mockReturnValue(builder)
+    builder.eq.mockReturnValue(builder)
+    builder.is.mockReturnValue(builder)
+    builder.neq.mockReturnValue(builder)
+    builder.update.mockReturnValue(builder)
+    builder.maybeSingle.mockResolvedValue(result)
+    builder.single.mockResolvedValue(result)
+
+    return builder
+}
+
+const websiteRecord = {
+    id: 'website-1',
+    client_id: 'client-1',
+}
+
+const r2ConfigRecord = {
+    bucket: 'iffers-pictures',
+    public_base_url: 'https://pub.example.test',
+    key_prefix: '',
+}
+
+const draftItem = {
+    id: 10,
+    website_id: 'website-1',
+    client_id: 'client-1',
+    key: 'events/baby-shower/source.jpg',
+    filename: 'source.jpg',
+    src: 'https://pub.example.test/events/baby-shower/source.jpg',
+    alt: 'Source image',
+    service: 'Events',
+    sub_category: 'Baby Shower',
+    aspect_ratio: 'portrait',
+    status: 'draft',
+    sort_order: 0,
+    created_at: '2026-05-27T12:00:00.000Z',
+    updated_at: '2026-05-27T12:30:00.000Z',
+    archived_at: null,
+    archived_by: null,
+    archived_from_status: null,
+}
+
+const notFoundError = Object.assign(new Error('not found'), {
+    name: 'NotFound',
+    $metadata: { httpStatusCode: 404 },
+})
+
+describe('media R2 object operations', () => {
+    beforeEach(() => {
+        mockState.from.mockReset()
+        mockState.send.mockReset()
+        mockState.updateItem.mockReset()
+        mockState.queryResults = []
+        mockState.builders = []
+        mockState.commands = []
+        mockState.from.mockImplementation(() => {
+            const builder = makeQueryBuilder(
+                mockState.queryResults.shift() || { data: null, error: null }
+            )
+            mockState.builders.push(builder)
+            return builder
+        })
+        process.env.R2_ACCESS_KEY_ID = 'test-access-key'
+        process.env.R2_SECRET_ACCESS_KEY = 'test-secret-key'
+        process.env.R2_ACCOUNT_ID = 'test-account'
+        process.env.R2_BUCKET_NAME = 'env-bucket'
+        process.env.R2_PUBLIC_BASE_URL = 'https://env-public.example.test'
+    })
+
+    it('lists R2 objects under a safe prefix', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+        ]
+        mockState.send.mockResolvedValue({
+            Contents: [
+                {
+                    Key: 'events/baby-shower/image.jpg',
+                    Size: 1234,
+                    LastModified: new Date('2026-05-27T12:00:00.000Z'),
+                    ETag: '"abc123"',
+                },
+            ],
+        })
+
+        const result = await mediaR2Service.listObjects({
+            websiteSlug: 'iffers-pictures',
+            prefix: '/events/baby-shower/',
+        })
+
+        expect(mockState.commands[0]).toEqual({
+            name: 'ListObjectsV2Command',
+            input: {
+                Bucket: 'iffers-pictures',
+                Prefix: 'events/baby-shower',
+                MaxKeys: 1000,
+            },
+        })
+        expect(result).toEqual({
+            bucket: 'iffers-pictures',
+            prefix: 'events/baby-shower',
+            objects: [
+                {
+                    key: 'events/baby-shower/image.jpg',
+                    public_url:
+                        'https://pub.example.test/events/baby-shower/image.jpg',
+                    size: 1234,
+                    last_modified: '2026-05-27T12:00:00.000Z',
+                    etag: 'abc123',
+                },
+            ],
+        })
+    })
+
+    it('reports destination availability across catalog and R2', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send.mockRejectedValueOnce(notFoundError)
+
+        await expect(
+            mediaR2Service.checkDestination({
+                websiteSlug: 'iffers-pictures',
+                destinationKey: 'events/baby-shower/new.jpg',
+            })
+        ).resolves.toEqual({
+            destination_key: 'events/baby-shower/new.jpg',
+            catalog_exists: false,
+            r2_exists: false,
+            available: true,
+        })
+    })
+
+    it('returns catalog destination collisions without overwriting objects', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: draftItem, error: null },
+            { data: { id: 99 }, error: null },
+        ]
+        mockState.send
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(notFoundError)
+
+        await expect(
+            mediaR2Service.moveCatalogItemObject({
+                websiteSlug: 'iffers-pictures',
+                id: 10,
+                destinationKey: 'events/baby-shower/collision.jpg',
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.destination_collision',
+        })
+        expect(
+            mockState.commands.some(command => command.name === 'CopyObjectCommand')
+        ).toBe(false)
+        expect(
+            mockState.commands.some(
+                command => command.name === 'DeleteObjectCommand'
+            )
+        ).toBe(false)
+        expect(mockState.updateItem).not.toHaveBeenCalled()
+    })
+
+    it('moves draft objects by copying, updating catalog metadata, and deleting source', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: draftItem, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(notFoundError)
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({})
+        mockState.updateItem.mockResolvedValue({
+            id: 10,
+            key: 'events/baby-shower/new-name.jpg',
+            filename: 'new-name.jpg',
+            src: 'https://pub.example.test/events/baby-shower/new-name.jpg',
+            alt: 'Source image',
+            service: 'Events',
+            subCategory: 'Baby Shower',
+            aspectRatio: 'portrait',
+            status: 'draft',
+            sortOrder: 0,
+        })
+
+        const result = await mediaR2Service.moveCatalogItemObject({
+            websiteSlug: 'iffers-pictures',
+            id: 10,
+            destinationKey: 'events/baby-shower/new-name.jpg',
+        })
+
+        expect(
+            mockState.commands.find(command => command.name === 'CopyObjectCommand')
+        ).toEqual({
+            name: 'CopyObjectCommand',
+            input: {
+                Bucket: 'iffers-pictures',
+                Key: 'events/baby-shower/new-name.jpg',
+                CopySource: 'iffers-pictures/events/baby-shower/source.jpg',
+            },
+        })
+        expect(mockState.updateItem).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            id: 10,
+            key: 'events/baby-shower/new-name.jpg',
+            filename: 'new-name.jpg',
+            src: 'https://pub.example.test/events/baby-shower/new-name.jpg',
+        })
+        expect(
+            mockState.commands.find(
+                command => command.name === 'DeleteObjectCommand'
+            )
+        ).toEqual({
+            name: 'DeleteObjectCommand',
+            input: {
+                Bucket: 'iffers-pictures',
+                Key: 'events/baby-shower/source.jpg',
+            },
+        })
+        expect(result).toEqual(
+            expect.objectContaining({
+                source_key: 'events/baby-shower/source.jpg',
+                destination_key: 'events/baby-shower/new-name.jpg',
+                source_deleted: true,
+            })
+        )
+    })
+
+    it('blocks published object moves', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: { ...draftItem, status: 'published' }, error: null },
+        ]
+
+        await expect(
+            mediaR2Service.moveCatalogItemObject({
+                websiteSlug: 'iffers-pictures',
+                id: 10,
+                destinationKey: 'events/baby-shower/new-name.jpg',
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.published_location_locked',
+        })
+        expect(mockState.send).not.toHaveBeenCalled()
+    })
+})

--- a/test/media-r2-objects.test.ts
+++ b/test/media-r2-objects.test.ts
@@ -94,6 +94,11 @@ const r2ConfigRecord = {
     key_prefix: '',
 }
 
+const prefixedR2ConfigRecord = {
+    ...r2ConfigRecord,
+    key_prefix: 'clients/iffers-pictures',
+}
+
 const draftItem = {
     id: 10,
     website_id: 'website-1',
@@ -112,6 +117,12 @@ const draftItem = {
     archived_at: null,
     archived_by: null,
     archived_from_status: null,
+}
+
+const prefixedDraftItem = {
+    ...draftItem,
+    key: 'clients/iffers-pictures/events/baby-shower/source.jpg',
+    src: 'https://pub.example.test/clients/iffers-pictures/events/baby-shower/source.jpg',
 }
 
 const notFoundError = Object.assign(new Error('not found'), {
@@ -204,6 +215,99 @@ describe('media R2 object operations', () => {
             catalog_exists: false,
             r2_exists: false,
             available: true,
+        })
+    })
+
+    it('scopes list, destination checks, and moves to configured key prefixes', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: prefixedR2ConfigRecord, error: null },
+        ]
+        mockState.send.mockResolvedValueOnce({
+            Contents: [
+                {
+                    Key: 'clients/iffers-pictures/events/baby-shower/image.jpg',
+                    Size: 1234,
+                    LastModified: new Date('2026-05-27T12:00:00.000Z'),
+                    ETag: '"abc123"',
+                },
+            ],
+        })
+
+        await expect(
+            mediaR2Service.listObjects({
+                websiteSlug: 'iffers-pictures',
+                prefix: 'events/baby-shower',
+            })
+        ).resolves.toMatchObject({
+            prefix: 'clients/iffers-pictures/events/baby-shower',
+        })
+        expect(mockState.commands[0]).toEqual({
+            name: 'ListObjectsV2Command',
+            input: {
+                Bucket: 'iffers-pictures',
+                Prefix: 'clients/iffers-pictures/events/baby-shower',
+                MaxKeys: 1000,
+            },
+        })
+
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: prefixedR2ConfigRecord, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send.mockRejectedValueOnce(notFoundError)
+
+        await expect(
+            mediaR2Service.checkDestination({
+                websiteSlug: 'iffers-pictures',
+                destinationKey: 'events/baby-shower/new.jpg',
+            })
+        ).resolves.toMatchObject({
+            destination_key: 'clients/iffers-pictures/events/baby-shower/new.jpg',
+            available: true,
+        })
+
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: prefixedR2ConfigRecord, error: null },
+            { data: prefixedDraftItem, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(notFoundError)
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({})
+        mockState.updateItem.mockResolvedValue({
+            id: 10,
+            key: 'clients/iffers-pictures/events/baby-shower/new-name.jpg',
+            filename: 'new-name.jpg',
+            src: 'https://pub.example.test/clients/iffers-pictures/events/baby-shower/new-name.jpg',
+            alt: 'Source image',
+            service: 'Events',
+            subCategory: 'Baby Shower',
+            aspectRatio: 'portrait',
+            status: 'draft',
+            sortOrder: 0,
+        })
+
+        await expect(
+            mediaR2Service.moveCatalogItemObject({
+                websiteSlug: 'iffers-pictures',
+                id: 10,
+                destinationKey: 'events/baby-shower/new-name.jpg',
+            })
+        ).resolves.toMatchObject({
+            destination_key:
+                'clients/iffers-pictures/events/baby-shower/new-name.jpg',
+        })
+        expect(mockState.updateItem).toHaveBeenLastCalledWith({
+            websiteSlug: 'iffers-pictures',
+            id: 10,
+            key: 'clients/iffers-pictures/events/baby-shower/new-name.jpg',
+            filename: 'new-name.jpg',
+            src: 'https://pub.example.test/clients/iffers-pictures/events/baby-shower/new-name.jpg',
         })
     })
 
@@ -364,5 +468,42 @@ describe('media R2 object operations', () => {
                 command => command.name === 'DeleteObjectCommand'
             )
         ).toBe(false)
+    })
+
+    it('cleans up the copied destination object when catalog update fails', async () => {
+        const updateError = new Error('catalog update failed')
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: draftItem, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send
+            .mockResolvedValueOnce({})
+            .mockRejectedValueOnce(notFoundError)
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({})
+        mockState.updateItem.mockRejectedValue(updateError)
+
+        await expect(
+            mediaR2Service.moveCatalogItemObject({
+                websiteSlug: 'iffers-pictures',
+                id: 10,
+                destinationKey: 'events/baby-shower/rollback.jpg',
+            })
+        ).rejects.toBe(updateError)
+
+        const deleteCommands = mockState.commands.filter(
+            command => command.name === 'DeleteObjectCommand'
+        )
+        expect(deleteCommands).toEqual([
+            {
+                name: 'DeleteObjectCommand',
+                input: {
+                    Bucket: 'iffers-pictures',
+                    Key: 'events/baby-shower/rollback.jpg',
+                },
+            },
+        ])
     })
 })


### PR DESCRIPTION
## Summary
- Add protected R2 object listing and destination collision check endpoints for media admins.
- Add a protected draft-only media move endpoint that checks source existence, checks catalog/R2 destination collisions, copies the R2 object, updates catalog metadata, and deletes the original object.
- Block published and archived item moves through this generic endpoint to prevent public breakage and preserve DEV-933 archive rules.
- Add focused tests for object listing, destination availability, catalog collision/no-overwrite behavior, successful draft move copy/update/delete flow, and published move lockout.

## API contract
- GET /api/media/:websiteSlug/admin/objects?prefix=events/baby-shower
- POST /api/media/:websiteSlug/admin/objects/check-destination with { "destination_key": "events/baby-shower/new.jpg", "exclude_media_id": 10 }
- POST /api/media/:websiteSlug/admin/items/:id/move with { "destination_key": "events/baby-shower/new.jpg" }

## Data and operational notes
- No migration required.
- No hard delete endpoint is exposed.
- Archive/restore remains catalog-level through the existing lifecycle patch endpoint.
- Move/rename is limited to draft items. Published items require a future explicit safe public-breakage-prevention flow; archived items must be restored before movement.

## Visual QA
None: backend API-only change.

## Logical QA
- List objects with and without a prefix and confirm object keys/public URLs match R2 contents.
- Check a destination that exists in catalog and confirm available=false/catalog_exists=true.
- Check a destination that exists only in R2 and confirm available=false/r2_exists=true.
- Move a draft item to an available key and confirm the catalog key/src/filename update and source object deletion.
- Attempt to move to an occupied destination and confirm media.destination_collision with no copy/delete.
- Attempt to move a published item and confirm media.published_location_locked.
- Attempt to move an archived item and confirm media.archived_locked.

## QA checklist
- Verify all new admin endpoints require a valid media admin session.
- Verify destination keys reject unsafe paths such as uppercase, leading slash, trailing slash, double slash, or .. segments.
- Verify no hard-delete route exists.
- Verify failed destination checks do not mutate catalog rows or R2 objects.

## Verification
- npm run build
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run test/media-r2-objects.test.ts test/media-r2-service.test.ts test/media-r2.test.ts
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run