### PR TITLE
DEV-936 Add media mutation audit trail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Store secrets outside version control. For Supabase service keys, restrict to ne
 -   Lead creation logs `id` and `email` to STDOUT after the Supabase insert succeeds; aggregate these logs centrally if compliance requires retention.
 -   Supabase’s `leads` table records `ip`, `user_agent`, and `created_at`, providing a persistent trail for submissions.
 -   Slack notifications intentionally include customer-facing submission details only; internal ids and attribution metadata stay in Supabase/reporting views unless explicitly added to an alert.
+-   Media catalog mutations attempt non-blocking inserts into `media_audit_logs` through `src/services/media-audit.ts`. Audit write failures are logged to STDERR and do not roll back the already-completed media mutation.
 
 ## When Adding Features
 

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -215,6 +215,7 @@ const moveCatalogItem = async (
             websiteSlug: req.params.websiteSlug,
             id: Number(req.params.id),
             destinationKey: parsed.destination_key,
+            actor: req.mediaAdmin?.email,
         })
 
         return res.status(200).json(result)
@@ -327,6 +328,7 @@ const createCatalogItem = async (
             subCategory: parsed.subCategory,
             aspectRatio: parsed.aspectRatio,
             sortOrder: parsed.sortOrder,
+            actor: req.mediaAdmin?.email,
         })
 
         return res.status(201).json(item)

--- a/src/services/media-audit.ts
+++ b/src/services/media-audit.ts
@@ -1,0 +1,62 @@
+import { db, Tables } from '../lib/db'
+
+export type MediaAuditAction =
+    | 'upload_created'
+    | 'draft_saved'
+    | 'published'
+    | 'archived'
+    | 'restored'
+    | 'renamed_moved'
+    | 'metadata_edited'
+    | 'reorder_changed'
+
+export interface MediaAuditLogInput {
+    websiteId: string
+    clientId: string
+    mediaId?: number | null
+    mediaKey?: string | null
+    action: MediaAuditAction
+    actor?: string | null
+    oldValues?: Record<string, unknown> | null
+    newValues?: Record<string, unknown> | null
+}
+
+const createLog = async ({
+    websiteId,
+    clientId,
+    mediaId,
+    mediaKey,
+    action,
+    actor,
+    oldValues,
+    newValues,
+}: MediaAuditLogInput): Promise<void> => {
+    const { error } = await db.from(Tables.MEDIA_AUDIT_LOGS).insert({
+        website_id: websiteId,
+        client_id: clientId,
+        media_id: mediaId ?? null,
+        media_key: mediaKey ?? null,
+        action,
+        actor: actor ?? null,
+        old_values: oldValues ?? null,
+        new_values: newValues ?? null,
+    })
+
+    if (error) throw error
+}
+
+const tryCreateLog = async (input: MediaAuditLogInput): Promise<void> => {
+    try {
+        await createLog(input)
+    } catch (err) {
+        console.error(
+            `Failed to write media audit log for ${input.action}: ${input.mediaKey || input.mediaId || 'unknown media'}`,
+            err
+        )
+    }
+}
+
+export default {
+    createLog,
+    tryCreateLog,
+}

--- a/src/services/media-catalog.ts
+++ b/src/services/media-catalog.ts
@@ -400,42 +400,160 @@ const changedValues = ({
     return { oldChangedValues, newChangedValues }
 }
 
-const determineUpdateAuditAction = ({
+const changedValuesForFields = ({
+    oldValues,
+    newValues,
+    fields,
+}: {
+    oldValues: Record<string, unknown>
+    newValues: Record<string, unknown>
+    fields: string[]
+}): {
+    oldChangedValues: Record<string, unknown>
+    newChangedValues: Record<string, unknown>
+} => {
+    const oldChangedValues: Record<string, unknown> = {}
+    const newChangedValues: Record<string, unknown> = {}
+
+    fields.forEach(field => {
+        if (oldValues[field] !== newValues[field]) {
+            oldChangedValues[field] = oldValues[field]
+            newChangedValues[field] = newValues[field]
+        }
+    })
+
+    return { oldChangedValues, newChangedValues }
+}
+
+const hasChangedValues = (values: Record<string, unknown>): boolean =>
+    Object.keys(values).length > 0
+
+const buildAuditChange = ({
+    action,
+    oldValues,
+    newValues,
+    fields,
+}: {
+    action: MediaAuditAction
+    oldValues: Record<string, unknown>
+    newValues: Record<string, unknown>
+    fields: string[]
+}): {
+    action: MediaAuditAction
+    oldValues: Record<string, unknown>
+    newValues: Record<string, unknown>
+} | null => {
+    const { oldChangedValues, newChangedValues } = changedValuesForFields({
+        oldValues,
+        newValues,
+        fields,
+    })
+
+    if (!hasChangedValues(newChangedValues)) return null
+
+    return {
+        action,
+        oldValues: oldChangedValues,
+        newValues: newChangedValues,
+    }
+}
+
+const determineUpdateAuditChanges = ({
     current,
     updated,
+    oldValues,
+    newValues,
 }: {
     current: MediaCatalogRecord
     updated: MediaCatalogRecord
-}): MediaAuditAction => {
-    if (
-        current.key !== updated.key ||
-        current.filename !== updated.filename ||
-        current.src !== updated.src
-    ) {
-        return 'renamed_moved'
-    }
+    oldValues: Record<string, unknown>
+    newValues: Record<string, unknown>
+}): Array<{
+    action: MediaAuditAction
+    oldValues: Record<string, unknown>
+    newValues: Record<string, unknown>
+}> => {
+    const changes: Array<{
+        action: MediaAuditAction
+        oldValues: Record<string, unknown>
+        newValues: Record<string, unknown>
+    }> = []
+
+    const locationChange = buildAuditChange({
+        action: 'renamed_moved',
+        oldValues,
+        newValues,
+        fields: ['key', 'filename', 'src'],
+    })
+    if (locationChange) changes.push(locationChange)
 
     if (current.status === 'archived' && updated.status !== 'archived') {
-        return 'restored'
+        const restoreChange = buildAuditChange({
+            action: 'restored',
+            oldValues,
+            newValues,
+            fields: ['status', 'archivedAt', 'archivedBy', 'archivedFromStatus'],
+        })
+        if (restoreChange) changes.push(restoreChange)
     }
 
     if (updated.status === 'archived' && current.status !== 'archived') {
-        return 'archived'
+        const archiveChange = buildAuditChange({
+            action: 'archived',
+            oldValues,
+            newValues,
+            fields: ['status', 'archivedAt', 'archivedBy', 'archivedFromStatus'],
+        })
+        if (archiveChange) changes.push(archiveChange)
     }
 
     if (updated.status === 'published' && current.status !== 'published') {
-        return 'published'
+        const publishChange = buildAuditChange({
+            action: 'published',
+            oldValues,
+            newValues,
+            fields: ['status'],
+        })
+        if (publishChange) changes.push(publishChange)
     }
 
-    if (current.sort_order !== updated.sort_order) {
-        return 'reorder_changed'
-    }
+    const metadataChange = buildAuditChange({
+        action: 'metadata_edited',
+        oldValues,
+        newValues,
+        fields: ['alt', 'service', 'subCategory', 'aspectRatio'],
+    })
+    if (metadataChange) changes.push(metadataChange)
+
+    const reorderChange = buildAuditChange({
+        action: 'reorder_changed',
+        oldValues,
+        newValues,
+        fields: ['sortOrder'],
+    })
+    if (reorderChange) changes.push(reorderChange)
 
     if (current.status === 'draft' && updated.status === 'draft') {
-        return 'draft_saved'
+        const { oldChangedValues, newChangedValues } = changedValues({
+            oldValues,
+            newValues,
+        })
+        if (hasChangedValues(newChangedValues)) {
+            changes.push({
+                action: 'draft_saved',
+                oldValues: oldChangedValues,
+                newValues: newChangedValues,
+            })
+        }
     }
 
-    return 'metadata_edited'
+    return changes
+}
+
+const queueAuditLog = (
+    input: Parameters<typeof mediaAuditService.tryCreateLog>[0]
+): void => {
+    void mediaAuditService.tryCreateLog(input)
 }
 
 const createItem = async (
@@ -457,7 +575,7 @@ const createItem = async (
     }
 
     const record = data as MediaCatalogRecord
-    await mediaAuditService.tryCreateLog({
+    queueAuditLog({
         websiteId: website.id,
         clientId: website.client_id,
         mediaId: record.id,
@@ -653,20 +771,22 @@ const updateItem = async (
     const updated = data as MediaCatalogRecord
     const oldValues = auditValuesForRecord(current)
     const newValues = auditValuesForRecord(updated)
-    const { oldChangedValues, newChangedValues } = changedValues({
+    determineUpdateAuditChanges({
+        current,
+        updated,
         oldValues,
         newValues,
-    })
-
-    await mediaAuditService.tryCreateLog({
-        websiteId: website.id,
-        clientId: website.client_id,
-        mediaId: updated.id,
-        mediaKey: updated.key,
-        action: determineUpdateAuditAction({ current, updated }),
-        actor: input.actor,
-        oldValues: oldChangedValues,
-        newValues: newChangedValues,
+    }).forEach(change => {
+        queueAuditLog({
+            websiteId: website.id,
+            clientId: website.client_id,
+            mediaId: updated.id,
+            mediaKey: updated.key,
+            action: change.action,
+            actor: input.actor,
+            oldValues: change.oldValues,
+            newValues: change.newValues,
+        })
     })
 
     return toCatalogItemResponse(updated, true)

--- a/src/services/media-catalog.ts
+++ b/src/services/media-catalog.ts
@@ -12,6 +12,7 @@ import {
     MediaStatus,
 } from '../lib/media-catalog'
 import { joinPublicUrl, MediaValidationError } from '../lib/media-r2'
+import mediaAuditService, { MediaAuditAction } from './media-audit'
 
 interface WebsiteRecord {
     id: string
@@ -84,6 +85,7 @@ export interface CreateMediaItemInput {
     subCategory?: string | null
     aspectRatio?: string | null
     sortOrder?: number
+    actor?: string
 }
 
 export interface UpdateMediaItemInput {
@@ -358,6 +360,84 @@ const buildValidatedDraftPayload = async ({
     }
 }
 
+const auditValuesForRecord = (
+    item: MediaCatalogRecord
+): Record<string, unknown> => ({
+    key: item.key,
+    filename: item.filename,
+    src: item.src,
+    alt: item.alt,
+    service: item.service,
+    subCategory: item.sub_category,
+    aspectRatio: item.aspect_ratio,
+    status: item.status,
+    sortOrder: item.sort_order,
+    archivedAt: item.archived_at,
+    archivedBy: item.archived_by,
+    archivedFromStatus: item.archived_from_status,
+})
+
+const changedValues = ({
+    oldValues,
+    newValues,
+}: {
+    oldValues: Record<string, unknown>
+    newValues: Record<string, unknown>
+}): {
+    oldChangedValues: Record<string, unknown>
+    newChangedValues: Record<string, unknown>
+} => {
+    const oldChangedValues: Record<string, unknown> = {}
+    const newChangedValues: Record<string, unknown> = {}
+
+    Object.entries(newValues).forEach(([key, value]) => {
+        if (oldValues[key] !== value) {
+            oldChangedValues[key] = oldValues[key]
+            newChangedValues[key] = value
+        }
+    })
+
+    return { oldChangedValues, newChangedValues }
+}
+
+const determineUpdateAuditAction = ({
+    current,
+    updated,
+}: {
+    current: MediaCatalogRecord
+    updated: MediaCatalogRecord
+}): MediaAuditAction => {
+    if (
+        current.key !== updated.key ||
+        current.filename !== updated.filename ||
+        current.src !== updated.src
+    ) {
+        return 'renamed_moved'
+    }
+
+    if (current.status === 'archived' && updated.status !== 'archived') {
+        return 'restored'
+    }
+
+    if (updated.status === 'archived' && current.status !== 'archived') {
+        return 'archived'
+    }
+
+    if (updated.status === 'published' && current.status !== 'published') {
+        return 'published'
+    }
+
+    if (current.sort_order !== updated.sort_order) {
+        return 'reorder_changed'
+    }
+
+    if (current.status === 'draft' && updated.status === 'draft') {
+        return 'draft_saved'
+    }
+
+    return 'metadata_edited'
+}
+
 const createItem = async (
     input: CreateMediaItemInput
 ): Promise<CatalogItemResponse> => {
@@ -375,7 +455,20 @@ const createItem = async (
         if (isUniqueViolation(error)) throwDuplicateKeyError(input.key)
         throw error
     }
-    return toCatalogItemResponse(data as MediaCatalogRecord, true)
+
+    const record = data as MediaCatalogRecord
+    await mediaAuditService.tryCreateLog({
+        websiteId: website.id,
+        clientId: website.client_id,
+        mediaId: record.id,
+        mediaKey: record.key,
+        action: 'upload_created',
+        actor: input.actor,
+        oldValues: null,
+        newValues: auditValuesForRecord(record),
+    })
+
+    return toCatalogItemResponse(record, true)
 }
 
 const getItemForWebsite = async ({
@@ -556,7 +649,27 @@ const updateItem = async (
         if (isUniqueViolation(error)) throwDuplicateKeyError(nextKey)
         throw error
     }
-    return toCatalogItemResponse(data as MediaCatalogRecord, true)
+
+    const updated = data as MediaCatalogRecord
+    const oldValues = auditValuesForRecord(current)
+    const newValues = auditValuesForRecord(updated)
+    const { oldChangedValues, newChangedValues } = changedValues({
+        oldValues,
+        newValues,
+    })
+
+    await mediaAuditService.tryCreateLog({
+        websiteId: website.id,
+        clientId: website.client_id,
+        mediaId: updated.id,
+        mediaKey: updated.key,
+        action: determineUpdateAuditAction({ current, updated }),
+        actor: input.actor,
+        oldValues: oldChangedValues,
+        newValues: newChangedValues,
+    })
+
+    return toCatalogItemResponse(updated, true)
 }
 
 export default {

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -77,6 +77,7 @@ export interface MoveCatalogItemInput {
     websiteSlug: string
     id: number
     destinationKey: string
+    actor?: string
 }
 
 export interface MoveCatalogItemResult {
@@ -543,6 +544,7 @@ const moveCatalogItemObject = async ({
     websiteSlug,
     id,
     destinationKey,
+    actor,
 }: MoveCatalogItemInput): Promise<MoveCatalogItemResult> => {
     const website = await getWebsiteBySlug(websiteSlug)
     if (!website) {
@@ -651,6 +653,7 @@ const moveCatalogItemObject = async ({
             key: scopedDestinationKey,
             filename: filenameFromKey(scopedDestinationKey),
             src: joinPublicUrl(config.publicBaseUrl, scopedDestinationKey),
+            actor,
         })
     } catch (err) {
         try {

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -498,18 +498,27 @@ describe('media catalog service', () => {
                 action: 'published',
                 actor: null,
                 old_values: expect.objectContaining({
+                    status: 'draft',
+                }),
+                new_values: expect.objectContaining({
+                    status: 'published',
+                }),
+            })
+        )
+        expect(mockState.builders[5].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'metadata_edited',
+                old_values: expect.objectContaining({
                     alt: '',
                     service: null,
                     subCategory: null,
                     aspectRatio: null,
-                    status: 'draft',
                 }),
                 new_values: expect.objectContaining({
                     alt: 'Jenn photographing a portrait session',
                     service: 'Portrait',
                     subCategory: 'Portrait',
                     aspectRatio: 'portrait',
-                    status: 'published',
                 }),
             })
         )
@@ -737,6 +746,8 @@ describe('media catalog service', () => {
                     status: 'draft',
                 })
             )
+            await Promise.resolve()
+            await Promise.resolve()
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 'Failed to write media audit log for upload_created: portrait/audit-failure.jpg',
                 auditError

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -14,6 +14,7 @@ vi.mock('../src/lib/db', () => ({
         WEBSITES: 'websites',
         MEDIA_R2_CONFIGS: 'media_r2_configs',
         MEDIA_CATALOG_ITEMS: 'media_catalog_items',
+        MEDIA_AUDIT_LOGS: 'media_audit_logs',
     },
     COLUMNS: {
         WEBSITE_SLUG: 'website_slug',
@@ -228,6 +229,7 @@ describe('media catalog service', () => {
         const item = await mediaCatalogService.createItem({
             websiteSlug: 'iffers-pictures',
             key: 'portrait/new-image.jpg',
+            actor: 'jenn@example.com',
         })
 
         expect(mockState.builders[3].insert).toHaveBeenCalledWith({
@@ -248,6 +250,22 @@ describe('media catalog service', () => {
                 key: 'portrait/new-image.jpg',
                 status: 'draft',
                 createdAt: '2026-05-27T12:00:00.000Z',
+            })
+        )
+        expect(mockState.from).toHaveBeenLastCalledWith('media_audit_logs')
+        expect(mockState.builders[4].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                website_id: 'website-1',
+                client_id: 'client-1',
+                media_id: 1,
+                media_key: 'portrait/new-image.jpg',
+                action: 'upload_created',
+                actor: 'jenn@example.com',
+                old_values: null,
+                new_values: expect.objectContaining({
+                    key: 'portrait/new-image.jpg',
+                    status: 'draft',
+                }),
             })
         )
     })
@@ -302,6 +320,61 @@ describe('media catalog service', () => {
             status: 409,
             code: 'media.published_location_locked',
         })
+    })
+
+    it('writes a renamed/moved audit entry for draft key changes', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: draftItem, error: null },
+            { data: null, error: null },
+            {
+                data: {
+                    ...draftItem,
+                    key: 'portrait/moved-draft.jpg',
+                    filename: 'moved-draft.jpg',
+                    src: 'https://pub.example.test/portrait/moved-draft.jpg',
+                },
+                error: null,
+            },
+        ]
+
+        const item = await mediaCatalogService.updateItem({
+            websiteSlug: 'iffers-pictures',
+            id: 3,
+            key: 'portrait/moved-draft.jpg',
+            actor: 'jenn@example.com',
+        })
+
+        expect(item).toEqual(
+            expect.objectContaining({
+                key: 'portrait/moved-draft.jpg',
+                filename: 'moved-draft.jpg',
+            })
+        )
+        expect(mockState.builders[5].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'renamed_moved',
+                actor: 'jenn@example.com',
+                old_values: expect.objectContaining({
+                    key: 'portrait/draft.jpg',
+                    filename: 'draft.jpg',
+                    src: 'https://pub.example.test/portrait/draft.jpg',
+                }),
+                new_values: expect.objectContaining({
+                    key: 'portrait/moved-draft.jpg',
+                    filename: 'moved-draft.jpg',
+                    src: 'https://pub.example.test/portrait/moved-draft.jpg',
+                }),
+            })
+        )
     })
 
     it('rejects invalid service and sub-category pairings', async () => {
@@ -415,6 +488,31 @@ describe('media catalog service', () => {
                 aspectRatio: 'portrait',
             })
         )
+        expect(mockState.from).toHaveBeenLastCalledWith('media_audit_logs')
+        expect(mockState.builders[4].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                website_id: 'website-1',
+                client_id: 'client-1',
+                media_id: 3,
+                media_key: 'portrait/draft.jpg',
+                action: 'published',
+                actor: null,
+                old_values: expect.objectContaining({
+                    alt: '',
+                    service: null,
+                    subCategory: null,
+                    aspectRatio: null,
+                    status: 'draft',
+                }),
+                new_values: expect.objectContaining({
+                    alt: 'Jenn photographing a portrait session',
+                    service: 'Portrait',
+                    subCategory: 'Portrait',
+                    aspectRatio: 'portrait',
+                    status: 'published',
+                }),
+            })
+        )
     })
 
     it('rejects blank status values before transition handling', async () => {
@@ -490,6 +588,23 @@ describe('media catalog service', () => {
                 archivedFromStatus: 'published',
             })
         )
+        expect(mockState.builders[4].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'archived',
+                actor: 'jenn@example.com',
+                old_values: expect.objectContaining({
+                    status: 'published',
+                    archivedAt: null,
+                    archivedBy: null,
+                    archivedFromStatus: null,
+                }),
+                new_values: expect.objectContaining({
+                    status: 'archived',
+                    archivedBy: 'jenn@example.com',
+                    archivedFromStatus: 'published',
+                }),
+            })
+        )
     })
 
     it('restores archived media to its previous status and clears archive metadata', async () => {
@@ -538,6 +653,21 @@ describe('media catalog service', () => {
                 archivedFromStatus: null,
             })
         )
+        expect(mockState.builders[4].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'restored',
+                old_values: expect.objectContaining({
+                    status: 'archived',
+                    archivedBy: 'admin@example.test',
+                    archivedFromStatus: 'published',
+                }),
+                new_values: expect.objectContaining({
+                    status: 'published',
+                    archivedBy: null,
+                    archivedFromStatus: null,
+                }),
+            })
+        )
     })
 
     it('blocks metadata edits while media is archived', async () => {
@@ -565,5 +695,54 @@ describe('media catalog service', () => {
             status: 409,
             code: 'media.archived_locked',
         })
+    })
+
+    it('logs audit failures without blocking successful catalog mutations', async () => {
+        const auditError = new Error('audit unavailable')
+        const consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined)
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: null, error: null },
+            {
+                data: {
+                    ...draftItem,
+                    key: 'portrait/audit-failure.jpg',
+                    filename: 'audit-failure.jpg',
+                    src: 'https://pub.example.test/portrait/audit-failure.jpg',
+                },
+                error: null,
+            },
+            { data: null, error: auditError },
+        ]
+
+        try {
+            await expect(
+                mediaCatalogService.createItem({
+                    websiteSlug: 'iffers-pictures',
+                    key: 'portrait/audit-failure.jpg',
+                })
+            ).resolves.toEqual(
+                expect.objectContaining({
+                    key: 'portrait/audit-failure.jpg',
+                    status: 'draft',
+                })
+            )
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                'Failed to write media audit log for upload_created: portrait/audit-failure.jpg',
+                auditError
+            )
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 })


### PR DESCRIPTION
## Summary
- Add a media audit service that writes media mutation records to media_audit_logs.
- Audit catalog item creation and catalog updates, including upload_created, published, archived, restored, renamed_moved, draft_saved, metadata_edited, and reorder_changed classification.
- Pass authenticated media admin emails through create and move flows so audit actor is captured.
- Document the intentional non-blocking audit failure behavior.

## Data and operational notes
- No migration required; media_audit_logs already exists in the media manager schema.
- Audit writes are non-blocking: failures are logged and do not roll back completed catalog/R2 mutations.
- Audit payloads include catalog item fields only; no R2 credentials, magic-link tokens, or session tokens are written.

## Visual QA
None: backend audit persistence only.

## Logical QA
- Create a draft media catalog item and verify a media_audit_logs row with action upload_created and the admin actor.
- Publish a draft and verify old/new metadata fields are captured with action published.
- Archive and restore media and verify archive metadata is captured in old/new values.
- Move or rename a draft item and verify action renamed_moved with old/new key, filename, and src.
- Simulate audit insert failure and confirm the catalog mutation still succeeds while the failure is logged.

## QA checklist
- [ ] Confirm all admin media mutation endpoints still require media admin session auth.
- [ ] Confirm media_audit_logs records include website_id, client_id, media_id, media_key, action, actor, old_values, and new_values.
- [ ] Confirm no secret env values, R2 credentials, magic-link tokens, or session cookies are present in audit rows.
- [ ] Confirm audit insert failures are visible in server logs and do not create partial catalog/R2 rollback behavior.

## Verification
- npm run build
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run test/media-catalog.test.ts
- /Users/phil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/vitest/vitest.mjs run