### PR TITLE
DEV-951 Implement media placement APIs

### DIFF
--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -103,6 +103,9 @@ Common codes:
 | `media.destination_collision` | Catalog or R2 already has the destination key. |
 | `media.published_location_locked` | Published object location cannot be changed by generic patch/move. |
 | `media.archived_locked` | Archived item must be restored before metadata/object edits. |
+| `media.invalid_placement_slot` | Placement slot key is not allowed for the website. |
+| `media.unpublished_assignment_forbidden` | Draft media cannot be assigned to a placement. |
+| `media.archived_assignment_forbidden` | Archived media cannot be assigned to a placement. |
 | `media.r2_not_configured` | R2 bucket/base URL or credentials are missing. |
 | `media.website_not_found` | Website slug was not found. |
 | `media.not_found` | Media item was not found for the website. |
@@ -135,6 +138,42 @@ const res = await fetch(`${apiBase}/api/media/iffers-pictures/catalog`, {
 const catalog = await res.json();
 ```
 
+## Public Placements
+
+`GET /api/media/:websiteSlug/placements`
+
+Returns explicit frontend placement assignments whose assigned media item is
+`published`. Draft and archived media are excluded from the public response.
+
+Response headers match the public catalog:
+
+`Cache-Control: public, max-age=60, stale-while-revalidate=300`
+
+Response:
+
+```json
+{
+  "version": 1,
+  "publicBaseUrl": "https://media.ifferspictures.com",
+  "placements": [
+    {
+      "slotKey": "home.hero",
+      "media": {
+        "id": 123,
+        "key": "events/baby-shower/baby-shower-01.jpg",
+        "filename": "baby-shower-01.jpg",
+        "src": "https://media.ifferspictures.com/events/baby-shower/baby-shower-01.jpg",
+        "alt": "Mother-to-be opening gifts at baby shower",
+        "service": "Events",
+        "subCategory": "Baby Shower",
+        "aspectRatio": "portrait",
+        "status": "published"
+      }
+    }
+  ]
+}
+```
+
 ## Admin Auth
 
 Auth details live in `docs/media-admin-auth.md`. The frontend flow is:
@@ -159,6 +198,75 @@ await fetch(`${apiBase}/api/media/iffers-pictures/admin/catalog`, {
 Returns draft, published, and archived items with admin metadata. Protected.
 
 Response headers include `Cache-Control: no-store`.
+
+## Admin Placements
+
+`GET /api/media/:websiteSlug/admin/placements`
+
+Protected. Returns every allowed placement slot for the website, with current
+assignment state when a slot has an assigned media item.
+
+Response headers include `Cache-Control: no-store`.
+
+```json
+{
+  "version": 1,
+  "publicBaseUrl": "https://media.ifferspictures.com",
+  "slots": [
+    {
+      "slotKey": "home.hero",
+      "pageLabel": "Home",
+      "sectionLabel": "Hero",
+      "description": "Primary homepage hero image.",
+      "expectedAspectRatios": ["landscape", "portrait"],
+      "affectedPaths": ["/"],
+      "assignment": {
+        "id": 10,
+        "updatedBy": "jenn@example.com",
+        "createdAt": "2026-06-06T12:00:00.000Z",
+        "updatedAt": "2026-06-06T12:30:00.000Z",
+        "media": {
+          "id": 123,
+          "key": "events/baby-shower/baby-shower-01.jpg",
+          "filename": "baby-shower-01.jpg",
+          "src": "https://media.ifferspictures.com/events/baby-shower/baby-shower-01.jpg",
+          "alt": "Mother-to-be opening gifts at baby shower",
+          "service": "Events",
+          "subCategory": "Baby Shower",
+          "aspectRatio": "portrait",
+          "status": "published"
+        }
+      }
+    }
+  ]
+}
+```
+
+`PUT /api/media/:websiteSlug/admin/placements/:slotKey`
+
+Protected. Assigns or replaces the media item for a placement slot. Only
+published media can be assigned. Draft and archived media are rejected.
+
+Request:
+
+```json
+{
+  "media_id": 123
+}
+```
+
+`DELETE /api/media/:websiteSlug/admin/placements/:slotKey`
+
+Protected. Clears a placement assignment by deleting the assignment row.
+
+Response:
+
+```json
+{
+  "cleared": true,
+  "slotKey": "home.hero"
+}
+```
 
 ## Presigned Upload
 

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { z, ZodError } from 'zod'
 
 import mediaCatalogService from '../services/media-catalog'
+import mediaPlacementsService from '../services/media-placements'
 import mediaR2Service from '../services/media-r2'
 import mediaRevalidationService from '../services/media-revalidation'
 import { MediaValidationError } from '../lib/media-r2'
@@ -63,6 +64,10 @@ const updateCatalogItemSchema = createCatalogItemSchema
     .refine(value => Object.keys(value).length > 0, {
         message: 'At least one field is required.',
     })
+
+const assignPlacementSchema = z.object({
+    media_id: z.number().int().positive(),
+})
 
 const sendMediaError = (
     res: Response,
@@ -301,6 +306,34 @@ const getPublicCatalog = async (
     }
 }
 
+const getPublicPlacements = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const placements = await mediaPlacementsService.listPublicPlacements({
+            websiteSlug: req.params.websiteSlug,
+        })
+
+        res.set('Cache-Control', mediaRevalidationService.publicCatalogCacheControl())
+        return res.status(200).json(placements)
+    } catch (err) {
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
 const revalidateCatalog = async (
     req: Request,
     res: Response
@@ -355,6 +388,123 @@ const getAdminCatalog = async (
         res.set('Cache-Control', 'no-store')
         return res.status(200).json(catalog)
     } catch (err) {
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const getAdminPlacements = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const placements = await mediaPlacementsService.listAdminPlacements({
+            websiteSlug: req.params.websiteSlug,
+        })
+
+        res.set('Cache-Control', 'no-store')
+        return res.status(200).json(placements)
+    } catch (err) {
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404
+                    ? 'media.website_not_found'
+                    : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const assignPlacement = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = assignPlacementSchema.parse(req.body)
+        const placement = await mediaPlacementsService.assignPlacement({
+            websiteSlug: req.params.websiteSlug,
+            slotKey: req.params.slotKey,
+            mediaId: parsed.media_id,
+            actor: req.mediaAdmin?.email,
+        })
+
+        res.set('Cache-Control', 'no-store')
+        return res.status(200).json(placement)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid media placement payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        if (typeof (err as { status?: unknown })?.status === 'number') {
+            const status = (err as { status: number }).status
+            const message =
+                err instanceof Error ? err.message : 'Media request failed'
+            const code =
+                status === 404 ? 'media.not_found' : 'media.r2_not_configured'
+
+            return sendMediaError(res, status, code, message)
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
+const clearPlacement = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const result = await mediaPlacementsService.clearPlacement({
+            websiteSlug: req.params.websiteSlug,
+            slotKey: req.params.slotKey,
+        })
+
+        res.set('Cache-Control', 'no-store')
+        return res.status(200).json(result)
+    } catch (err) {
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
         if (typeof (err as { status?: unknown })?.status === 'number') {
             const status = (err as { status: number }).status
             const message =
@@ -494,8 +644,12 @@ export default {
     checkDestination,
     moveCatalogItem,
     getPublicCatalog,
+    getPublicPlacements,
     getAdminCatalog,
+    getAdminPlacements,
     revalidateCatalog,
     createCatalogItem,
     updateCatalogItem,
+    assignPlacement,
+    clearPlacement,
 }

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -21,6 +21,19 @@ router.get(
 )
 
 router.get(
+    `${BASE_ROUTE}/:websiteSlug/placements`,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+    ],
+    validateRequest,
+    media.getPublicPlacements
+)
+
+router.get(
     `${BASE_ROUTE}/:websiteSlug/admin/catalog`,
     requireMediaAdminSession,
     [
@@ -32,6 +45,61 @@ router.get(
     ],
     validateRequest,
     media.getAdminCatalog
+)
+
+router.get(
+    `${BASE_ROUTE}/:websiteSlug/admin/placements`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+    ],
+    validateRequest,
+    media.getAdminPlacements
+)
+
+router.put(
+    `${BASE_ROUTE}/:websiteSlug/admin/placements/:slotKey`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        param('slotKey')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('slotKey is required'),
+        body('media_id')
+            .isInt({ min: 1 })
+            .withMessage('media_id must be a positive integer'),
+    ],
+    validateRequest,
+    media.assignPlacement
+)
+
+router.delete(
+    `${BASE_ROUTE}/:websiteSlug/admin/placements/:slotKey`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        param('slotKey')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('slotKey is required'),
+    ],
+    validateRequest,
+    media.clearPlacement
 )
 
 router.get(

--- a/src/services/media-placements.ts
+++ b/src/services/media-placements.ts
@@ -1,0 +1,471 @@
+import { COLUMNS, db, Tables } from '../lib/db'
+import {
+    MEDIA_PLACEMENTS_VERSION,
+    MediaPlacementSlot,
+    assertValidMediaPlacementSlot,
+    getMediaPlacementSlotsForWebsite,
+} from '../lib/media-placements'
+import type {
+    CatalogItemResponse,
+    MediaCatalogRecord,
+} from './media-catalog'
+import { MediaValidationError } from '../lib/media-r2'
+
+interface WebsiteRecord {
+    id: string
+    client_id: string
+}
+
+interface R2ConfigRecord {
+    bucket: string
+    public_base_url: string
+    key_prefix: string | null
+}
+
+interface ResolvedR2Config {
+    bucket: string
+    publicBaseUrl: string
+}
+
+interface MediaPlacementRecord {
+    id: number
+    website_id: string
+    client_id: string
+    slot_key: string
+    media_id: number
+    updated_by: string | null
+    created_at: string
+    updated_at: string
+}
+
+export interface PlacementMediaResponse
+    extends Omit<CatalogItemResponse, 'sortOrder'> {}
+
+export interface PublicPlacementResponse {
+    slotKey: string
+    media: PlacementMediaResponse
+}
+
+export interface PublicPlacementsResponse {
+    version: 1
+    publicBaseUrl: string
+    placements: PublicPlacementResponse[]
+}
+
+export interface AdminPlacementSlotResponse {
+    slotKey: string
+    pageLabel: string
+    sectionLabel: string
+    description: string
+    expectedAspectRatios?: string[]
+    affectedPaths: string[]
+    assignment: {
+        id: number
+        media: PlacementMediaResponse
+        updatedBy: string | null
+        createdAt: string
+        updatedAt: string
+    } | null
+}
+
+export interface AdminPlacementsResponse {
+    version: 1
+    publicBaseUrl: string
+    slots: AdminPlacementSlotResponse[]
+}
+
+export interface AssignPlacementInput {
+    websiteSlug: string
+    slotKey: string
+    mediaId: number
+    actor?: string
+}
+
+export interface ClearPlacementInput {
+    websiteSlug: string
+    slotKey: string
+}
+
+const getWebsiteBySlug = async (
+    websiteSlug: string
+): Promise<WebsiteRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.WEBSITES)
+        .select('id, client_id')
+        .eq(COLUMNS.WEBSITE_SLUG, websiteSlug)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as WebsiteRecord | null
+}
+
+const getWebsiteOrThrow = async (websiteSlug: string): Promise<WebsiteRecord> => {
+    const website = await getWebsiteBySlug(websiteSlug)
+    if (!website) {
+        const err = new Error('Website not found') as Error & { status?: number }
+        err.status = 404
+        throw err
+    }
+
+    return website
+}
+
+const getWebsiteR2Config = async (
+    website: WebsiteRecord
+): Promise<R2ConfigRecord | null> => {
+    const { data: websiteConfig, error: websiteError } = await db
+        .from(Tables.MEDIA_R2_CONFIGS)
+        .select('bucket, public_base_url, key_prefix')
+        .eq('website_id', website.id)
+        .maybeSingle()
+
+    if (websiteError) throw websiteError
+    if (websiteConfig) return websiteConfig as R2ConfigRecord
+
+    const { data: clientConfig, error: clientError } = await db
+        .from(Tables.MEDIA_R2_CONFIGS)
+        .select('bucket, public_base_url, key_prefix')
+        .eq('client_id', website.client_id)
+        .is('website_id', null)
+        .maybeSingle()
+
+    if (clientError) throw clientError
+    return clientConfig as R2ConfigRecord | null
+}
+
+const resolveR2Config = async (
+    website: WebsiteRecord
+): Promise<ResolvedR2Config> => {
+    const persistedConfig = await getWebsiteR2Config(website)
+    const bucket = persistedConfig?.bucket || process.env.R2_BUCKET_NAME
+    const publicBaseUrl =
+        persistedConfig?.public_base_url || process.env.R2_PUBLIC_BASE_URL
+
+    if (!bucket || !publicBaseUrl) {
+        const err = new Error('R2 media configuration is not available') as Error & {
+            status?: number
+        }
+        err.status = 503
+        throw err
+    }
+
+    return { bucket, publicBaseUrl }
+}
+
+const toPlacementMediaResponse = (
+    item: MediaCatalogRecord
+): PlacementMediaResponse => ({
+    id: item.id,
+    key: item.key,
+    filename: item.filename,
+    src: item.src,
+    alt: item.alt,
+    service: item.service,
+    subCategory: item.sub_category,
+    aspectRatio: item.aspect_ratio,
+    status: item.status,
+})
+
+const listPlacementRecords = async (
+    websiteId: string
+): Promise<MediaPlacementRecord[]> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_PLACEMENTS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .order('slot_key', { ascending: true })
+
+    if (error) throw error
+    return (data || []) as MediaPlacementRecord[]
+}
+
+const getPlacementRecord = async ({
+    websiteId,
+    slotKey,
+}: {
+    websiteId: string
+    slotKey: string
+}): Promise<MediaPlacementRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_PLACEMENTS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .eq('slot_key', slotKey)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as MediaPlacementRecord | null
+}
+
+const listMediaByIds = async ({
+    websiteId,
+    ids,
+}: {
+    websiteId: string
+    ids: number[]
+}): Promise<MediaCatalogRecord[]> => {
+    if (ids.length === 0) return []
+
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .in('id', ids)
+
+    if (error) throw error
+    return (data || []) as MediaCatalogRecord[]
+}
+
+const getMediaForWebsite = async ({
+    websiteId,
+    mediaId,
+}: {
+    websiteId: string
+    mediaId: number
+}): Promise<MediaCatalogRecord | null> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .eq('id', mediaId)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as MediaCatalogRecord | null
+}
+
+const mediaById = (
+    items: MediaCatalogRecord[]
+): Map<number, MediaCatalogRecord> =>
+    new Map(items.map(item => [item.id, item]))
+
+const assignmentForSlot = ({
+    slot,
+    placement,
+    media,
+}: {
+    slot: MediaPlacementSlot
+    placement?: MediaPlacementRecord
+    media?: MediaCatalogRecord
+}): AdminPlacementSlotResponse => ({
+    slotKey: slot.key,
+    pageLabel: slot.pageLabel,
+    sectionLabel: slot.sectionLabel,
+    description: slot.description,
+    ...(slot.expectedAspectRatios && {
+        expectedAspectRatios: [...slot.expectedAspectRatios],
+    }),
+    affectedPaths: [...slot.affectedPaths],
+    assignment:
+        placement && media
+            ? {
+                  id: placement.id,
+                  media: toPlacementMediaResponse(media),
+                  updatedBy: placement.updated_by,
+                  createdAt: placement.created_at,
+                  updatedAt: placement.updated_at,
+              }
+            : null,
+})
+
+const listPublicPlacements = async ({
+    websiteSlug,
+}: {
+    websiteSlug: string
+}): Promise<PublicPlacementsResponse> => {
+    const website = await getWebsiteOrThrow(websiteSlug)
+    const config = await resolveR2Config(website)
+    const allowedSlotKeys = new Set(
+        getMediaPlacementSlotsForWebsite(websiteSlug).map(slot => slot.key)
+    )
+    const placements = (await listPlacementRecords(website.id)).filter(
+        placement => allowedSlotKeys.has(placement.slot_key)
+    )
+    const mediaMap = mediaById(
+        await listMediaByIds({
+            websiteId: website.id,
+            ids: placements.map(placement => placement.media_id),
+        })
+    )
+
+    return {
+        version: MEDIA_PLACEMENTS_VERSION,
+        publicBaseUrl: config.publicBaseUrl,
+        placements: placements
+            .map(placement => {
+                const media = mediaMap.get(placement.media_id)
+                if (!media || media.status !== 'published') return null
+
+                return {
+                    slotKey: placement.slot_key,
+                    media: toPlacementMediaResponse(media),
+                }
+            })
+            .filter(
+                (placement): placement is PublicPlacementResponse =>
+                    placement !== null
+            ),
+    }
+}
+
+const listAdminPlacements = async ({
+    websiteSlug,
+}: {
+    websiteSlug: string
+}): Promise<AdminPlacementsResponse> => {
+    const website = await getWebsiteOrThrow(websiteSlug)
+    const config = await resolveR2Config(website)
+    const slots = getMediaPlacementSlotsForWebsite(websiteSlug)
+    const placements = await listPlacementRecords(website.id)
+    const mediaMap = mediaById(
+        await listMediaByIds({
+            websiteId: website.id,
+            ids: placements.map(placement => placement.media_id),
+        })
+    )
+    const placementMap = new Map(
+        placements.map(placement => [placement.slot_key, placement])
+    )
+
+    return {
+        version: MEDIA_PLACEMENTS_VERSION,
+        publicBaseUrl: config.publicBaseUrl,
+        slots: slots.map(slot =>
+            assignmentForSlot({
+                slot,
+                placement: placementMap.get(slot.key),
+                media: placementMap.get(slot.key)
+                    ? mediaMap.get(placementMap.get(slot.key)?.media_id || 0)
+                    : undefined,
+            })
+        ),
+    }
+}
+
+const assertAssignableMedia = (media: MediaCatalogRecord | null): void => {
+    if (!media) {
+        const err = new Error('Media catalog item not found') as Error & {
+            status?: number
+        }
+        err.status = 404
+        throw err
+    }
+
+    if (media.status === 'archived') {
+        throw new MediaValidationError(
+            409,
+            'media.archived_assignment_forbidden',
+            'Archived media cannot be assigned to a placement.',
+            { mediaId: media.id, status: media.status }
+        )
+    }
+
+    if (media.status !== 'published') {
+        throw new MediaValidationError(
+            409,
+            'media.unpublished_assignment_forbidden',
+            'Only published media can be assigned to placements.',
+            { mediaId: media.id, status: media.status }
+        )
+    }
+}
+
+const upsertPlacement = async ({
+    website,
+    slotKey,
+    mediaId,
+    actor,
+    current,
+}: {
+    website: WebsiteRecord
+    slotKey: string
+    mediaId: number
+    actor?: string
+    current: MediaPlacementRecord | null
+}): Promise<MediaPlacementRecord> => {
+    const payload = {
+        website_id: website.id,
+        client_id: website.client_id,
+        slot_key: slotKey,
+        media_id: mediaId,
+        updated_by: actor || null,
+    }
+
+    const query = current
+        ? db
+              .from(Tables.MEDIA_PLACEMENTS)
+              .update(payload)
+              .eq('id', current.id)
+        : db.from(Tables.MEDIA_PLACEMENTS).insert(payload)
+
+    const { data, error } = await query.select('*').single()
+
+    if (error) throw error
+    return data as MediaPlacementRecord
+}
+
+const assignPlacement = async (
+    input: AssignPlacementInput
+): Promise<AdminPlacementSlotResponse> => {
+    const slot = assertValidMediaPlacementSlot({
+        websiteSlug: input.websiteSlug,
+        slotKey: input.slotKey,
+    })
+    const website = await getWebsiteOrThrow(input.websiteSlug)
+    const media = await getMediaForWebsite({
+        websiteId: website.id,
+        mediaId: input.mediaId,
+    })
+    assertAssignableMedia(media)
+
+    const current = await getPlacementRecord({
+        websiteId: website.id,
+        slotKey: input.slotKey,
+    })
+    const placement = await upsertPlacement({
+        website,
+        slotKey: input.slotKey,
+        mediaId: input.mediaId,
+        actor: input.actor,
+        current,
+    })
+
+    return assignmentForSlot({
+        slot,
+        placement,
+        media: media as MediaCatalogRecord,
+    })
+}
+
+const clearPlacement = async (
+    input: ClearPlacementInput
+): Promise<{ cleared: boolean; slotKey: string }> => {
+    assertValidMediaPlacementSlot({
+        websiteSlug: input.websiteSlug,
+        slotKey: input.slotKey,
+    })
+    const website = await getWebsiteOrThrow(input.websiteSlug)
+    const current = await getPlacementRecord({
+        websiteId: website.id,
+        slotKey: input.slotKey,
+    })
+
+    if (!current) {
+        return { cleared: false, slotKey: input.slotKey }
+    }
+
+    const { error } = await db
+        .from(Tables.MEDIA_PLACEMENTS)
+        .delete()
+        .eq('id', current.id)
+
+    if (error) throw error
+    return { cleared: true, slotKey: input.slotKey }
+}
+
+export default {
+    listPublicPlacements,
+    listAdminPlacements,
+    assignPlacement,
+    clearPlacement,
+}

--- a/test/media-placements-service.test.ts
+++ b/test/media-placements-service.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+    from: vi.fn(),
+    queryResults: [] as Array<{ data: unknown; error: unknown }>,
+    builders: [] as Array<Record<string, ReturnType<typeof vi.fn>>>,
+}))
+
+vi.mock('../src/lib/db', () => ({
+    db: {
+        from: mockState.from,
+    },
+    Tables: {
+        WEBSITES: 'websites',
+        MEDIA_R2_CONFIGS: 'media_r2_configs',
+        MEDIA_CATALOG_ITEMS: 'media_catalog_items',
+        MEDIA_PLACEMENTS: 'media_placements',
+    },
+    COLUMNS: {
+        WEBSITE_SLUG: 'website_slug',
+    },
+}))
+
+import mediaPlacementsService from '../src/services/media-placements'
+
+const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
+    const builder = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        is: vi.fn(),
+        in: vi.fn(),
+        order: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        maybeSingle: vi.fn(),
+        single: vi.fn(),
+        then: vi.fn(),
+    }
+
+    builder.select.mockReturnValue(builder)
+    builder.eq.mockReturnValue(builder)
+    builder.is.mockReturnValue(builder)
+    builder.in.mockReturnValue(builder)
+    builder.order.mockReturnValue(builder)
+    builder.insert.mockReturnValue(builder)
+    builder.update.mockReturnValue(builder)
+    builder.delete.mockReturnValue(builder)
+    builder.maybeSingle.mockResolvedValue(result)
+    builder.single.mockResolvedValue(result)
+    builder.then.mockImplementation((resolve, reject) =>
+        Promise.resolve(result).then(resolve, reject)
+    )
+
+    return builder
+}
+
+const website = { id: 'website-1', client_id: 'client-1' }
+
+const r2Config = {
+    bucket: 'iffers-pictures',
+    public_base_url: 'https://media.ifferspictures.com',
+    key_prefix: '',
+}
+
+const placement = {
+    id: 10,
+    website_id: 'website-1',
+    client_id: 'client-1',
+    slot_key: 'home.hero',
+    media_id: 1,
+    updated_by: 'jenn@example.com',
+    created_at: '2026-06-06T12:00:00.000Z',
+    updated_at: '2026-06-06T12:30:00.000Z',
+}
+
+const publishedMedia = {
+    id: 1,
+    website_id: 'website-1',
+    client_id: 'client-1',
+    key: 'events/baby-shower/baby.jpg',
+    filename: 'baby.jpg',
+    src: 'https://media.ifferspictures.com/events/baby-shower/baby.jpg',
+    alt: 'Baby shower detail',
+    service: 'Events',
+    sub_category: 'Baby Shower',
+    aspect_ratio: 'portrait',
+    status: 'published',
+    sort_order: 0,
+    created_at: '2026-06-06T12:00:00.000Z',
+    updated_at: '2026-06-06T12:00:00.000Z',
+    archived_at: null,
+    archived_by: null,
+    archived_from_status: null,
+}
+
+const draftMedia = {
+    ...publishedMedia,
+    id: 2,
+    key: 'draft.jpg',
+    filename: 'draft.jpg',
+    status: 'draft',
+}
+
+const archivedMedia = {
+    ...publishedMedia,
+    id: 3,
+    key: 'archived.jpg',
+    filename: 'archived.jpg',
+    status: 'archived',
+    archived_at: '2026-06-06T14:00:00.000Z',
+    archived_by: 'jenn@example.com',
+    archived_from_status: 'published',
+}
+
+describe('media placements service', () => {
+    beforeEach(() => {
+        mockState.from.mockReset()
+        mockState.queryResults = []
+        mockState.builders = []
+        mockState.from.mockImplementation(() => {
+            const builder = makeQueryBuilder(
+                mockState.queryResults.shift() || {
+                    data: null,
+                    error: null,
+                }
+            )
+            mockState.builders.push(builder)
+            return builder
+        })
+        process.env.R2_BUCKET_NAME = 'iffers-pictures'
+        process.env.R2_PUBLIC_BASE_URL = 'https://env-pub.example.test'
+    })
+
+    it('returns public placements backed only by published media', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: r2Config, error: null },
+            {
+                data: [
+                    placement,
+                    { ...placement, id: 11, slot_key: 'home.strip.1', media_id: 2 },
+                    { ...placement, id: 12, slot_key: 'home.strip.2', media_id: 3 },
+                    { ...placement, id: 13, slot_key: 'legacy.hero', media_id: 1 },
+                ],
+                error: null,
+            },
+            { data: [publishedMedia, draftMedia, archivedMedia], error: null },
+        ]
+
+        const result = await mediaPlacementsService.listPublicPlacements({
+            websiteSlug: 'iffers-pictures',
+        })
+
+        expect(result).toEqual({
+            version: 1,
+            publicBaseUrl: 'https://media.ifferspictures.com',
+            placements: [
+                {
+                    slotKey: 'home.hero',
+                    media: {
+                        id: 1,
+                        key: 'events/baby-shower/baby.jpg',
+                        filename: 'baby.jpg',
+                        src: 'https://media.ifferspictures.com/events/baby-shower/baby.jpg',
+                        alt: 'Baby shower detail',
+                        service: 'Events',
+                        subCategory: 'Baby Shower',
+                        aspectRatio: 'portrait',
+                        status: 'published',
+                    },
+                },
+            ],
+        })
+        expect(mockState.builders[3].in).toHaveBeenCalledWith('id', [1, 2, 3])
+    })
+
+    it('returns all admin slots with current assignment metadata', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: r2Config, error: null },
+            { data: [placement], error: null },
+            { data: [publishedMedia], error: null },
+        ]
+
+        const result = await mediaPlacementsService.listAdminPlacements({
+            websiteSlug: 'iffers-pictures',
+        })
+
+        expect(result.slots).toHaveLength(16)
+        expect(result.slots[0]).toEqual(
+            expect.objectContaining({
+                slotKey: 'home.hero',
+                pageLabel: 'Home',
+                assignment: expect.objectContaining({
+                    id: 10,
+                    updatedBy: 'jenn@example.com',
+                    media: expect.objectContaining({
+                        id: 1,
+                        status: 'published',
+                    }),
+                }),
+            })
+        )
+        expect(result.slots.find(slot => slot.slotKey === 'faq.hero')).toEqual(
+            expect.objectContaining({ assignment: null })
+        )
+    })
+
+    it('assigns a published media item by inserting a new placement row', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: publishedMedia, error: null },
+            { data: null, error: null },
+            { data: placement, error: null },
+        ]
+
+        const result = await mediaPlacementsService.assignPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.hero',
+            mediaId: 1,
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.builders[3].insert).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            slot_key: 'home.hero',
+            media_id: 1,
+            updated_by: 'jenn@example.com',
+        })
+        expect(result.assignment?.media.id).toBe(1)
+    })
+
+    it('replaces an existing placement row', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: publishedMedia, error: null },
+            { data: placement, error: null },
+            { data: { ...placement, media_id: 1 }, error: null },
+        ]
+
+        await mediaPlacementsService.assignPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.hero',
+            mediaId: 1,
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.builders[3].update).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            slot_key: 'home.hero',
+            media_id: 1,
+            updated_by: 'jenn@example.com',
+        })
+        expect(mockState.builders[3].eq).toHaveBeenCalledWith('id', 10)
+    })
+
+    it('rejects unknown placement slots before querying Supabase', async () => {
+        await expect(
+            mediaPlacementsService.assignPlacement({
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.unknown',
+                mediaId: 1,
+            })
+        ).rejects.toMatchObject({
+            status: 400,
+            code: 'media.invalid_placement_slot',
+        })
+        expect(mockState.from).not.toHaveBeenCalled()
+    })
+
+    it('rejects draft and archived media assignment', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: draftMedia, error: null },
+        ]
+
+        await expect(
+            mediaPlacementsService.assignPlacement({
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.hero',
+                mediaId: 2,
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.unpublished_assignment_forbidden',
+        })
+
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: archivedMedia, error: null },
+        ]
+
+        await expect(
+            mediaPlacementsService.assignPlacement({
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.hero',
+                mediaId: 3,
+            })
+        ).rejects.toMatchObject({
+            status: 409,
+            code: 'media.archived_assignment_forbidden',
+        })
+    })
+
+    it('rejects cross-tenant media assignment as not found', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: null, error: null },
+        ]
+
+        await expect(
+            mediaPlacementsService.assignPlacement({
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.hero',
+                mediaId: 999,
+            })
+        ).rejects.toMatchObject({
+            status: 404,
+        })
+        expect(mockState.builders[1].eq).toHaveBeenCalledWith(
+            'website_id',
+            'website-1'
+        )
+        expect(mockState.builders[1].eq).toHaveBeenCalledWith('id', 999)
+    })
+
+    it('clears an existing placement by deleting the row', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: placement, error: null },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaPlacementsService.clearPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.hero',
+        })
+
+        expect(result).toEqual({ cleared: true, slotKey: 'home.hero' })
+        expect(mockState.builders[2].delete).toHaveBeenCalled()
+        expect(mockState.builders[2].eq).toHaveBeenCalledWith('id', 10)
+    })
+})

--- a/test/media-r2.test.ts
+++ b/test/media-r2.test.ts
@@ -23,6 +23,15 @@ vi.mock('../src/services/media-catalog', () => ({
     },
 }))
 
+vi.mock('../src/services/media-placements', () => ({
+    default: {
+        listPublicPlacements: vi.fn(),
+        listAdminPlacements: vi.fn(),
+        assignPlacement: vi.fn(),
+        clearPlacement: vi.fn(),
+    },
+}))
+
 const createResponse = () => {
     const res = {
         status: vi.fn(),


### PR DESCRIPTION
## Summary
- add public and admin media placement endpoints under /api/media/:websiteSlug
- add a media placements service for listing public published placements, listing admin slots, assigning/replacing slots, and clearing slots
- validate allowed placement slots through the DEV-950 registry and reject draft/archived media assignments
- document public/admin placement contracts and structured placement errors
- add focused placement service tests for public filtering, admin slot state, assignment, replacement, clear, unknown slots, and cross-tenant rejection

## Risks / Follow-up
- Audit logging and revalidation for placement mutations are intentionally deferred to DEV-952.
- Public reads filter to registry-approved slots so stale/manual DB rows for unknown slots do not render.
- Only published media can be assigned; draft assignment is intentionally rejected and documented.

## Visual QA
None: backend API contract only.

## Logical QA
- Verify GET /api/media/iffers-pictures/placements returns only published assigned media.
- Verify GET /api/media/iffers-pictures/admin/placements requires a valid media admin session and returns all allowed slots.
- Verify PUT /api/media/iffers-pictures/admin/placements/home.hero with a published media_id assigns/replaces that slot.
- Verify PUT rejects unknown slot keys, draft media, archived media, and media from another website.
- Verify DELETE /api/media/iffers-pictures/admin/placements/home.hero clears the assignment row.

## QA Checklist
- Run npm test.
- Run npm run build.
- Apply DEV-950 migration in local/staging before exercising these endpoints.
- Seed or use an existing published media_catalog_items row for iffers-pictures.
- Confirm public placement response includes slotKey and render-ready media fields.
- Confirm admin placement response includes slot labels, descriptions, aspect guidance, affected paths, and assignment state.