### PR TITLE
DEV-952 Integrate placement audit and revalidation

### DIFF
--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -246,6 +246,8 @@ Response headers include `Cache-Control: no-store`.
 
 Protected. Assigns or replaces the media item for a placement slot. Only
 published media can be assigned. Draft and archived media are rejected.
+Successful assignment or replacement writes a non-blocking audit log and
+triggers targeted frontend revalidation for the slot's `affectedPaths`.
 
 Request:
 
@@ -258,6 +260,8 @@ Request:
 `DELETE /api/media/:websiteSlug/admin/placements/:slotKey`
 
 Protected. Clears a placement assignment by deleting the assignment row.
+Successful clears write a non-blocking audit log with the old placement state
+and trigger targeted frontend revalidation for the slot's `affectedPaths`.
 
 Response:
 
@@ -505,6 +509,9 @@ Request:
 - `metadata_edited`
 - `reorder_changed`
 - `renamed_moved`
+- `placement_assigned`
+- `placement_replaced`
+- `placement_cleared`
 
 Response when `MEDIA_REVALIDATION_WEBHOOK_URL` is configured:
 
@@ -566,8 +573,21 @@ public output:
 - editing published alt text, category, or aspect ratio
 - changing published sort order
 
+Automatic non-blocking revalidation also runs after placement mutations. Catalog
+mutations use the full media-heavy path list. Placement mutations use the
+targeted `affectedPaths` from the backend slot registry, for example
+`home.* -> ["/"]`, `about.hero -> ["/about"]`, and
+`services.events.hero -> ["/services/events"]`.
+
 Webhook failures during automatic revalidation are logged and do not roll back
-the completed catalog mutation.
+the completed catalog or placement mutation.
+
+Placement assignment, replacement, and clearing also write non-blocking
+`media_audit_logs` rows with actions `placement_assigned`,
+`placement_replaced`, and `placement_cleared`. The audit payload stores previous
+and new placement state in `old_values` and `new_values`, including `slotKey`,
+`mediaId`, `mediaKey`, `src`, filename, metadata, and actor context where
+available.
 
 ## Frontend Revalidation Webhook
 

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -34,6 +34,9 @@ const revalidateCatalogSchema = z.object({
             'metadata_edited',
             'reorder_changed',
             'renamed_moved',
+            'placement_assigned',
+            'placement_replaced',
+            'placement_cleared',
         ])
         .optional()
         .default('manual'),
@@ -490,6 +493,7 @@ const clearPlacement = async (
         const result = await mediaPlacementsService.clearPlacement({
             websiteSlug: req.params.websiteSlug,
             slotKey: req.params.slotKey,
+            actor: req.mediaAdmin?.email,
         })
 
         res.set('Cache-Control', 'no-store')

--- a/src/services/media-audit.ts
+++ b/src/services/media-audit.ts
@@ -9,6 +9,9 @@ export type MediaAuditAction =
     | 'renamed_moved'
     | 'metadata_edited'
     | 'reorder_changed'
+    | 'placement_assigned'
+    | 'placement_replaced'
+    | 'placement_cleared'
 
 export interface MediaAuditLogInput {
     websiteId: string

--- a/src/services/media-placements.ts
+++ b/src/services/media-placements.ts
@@ -10,6 +10,8 @@ import type {
     MediaCatalogRecord,
 } from './media-catalog'
 import { MediaValidationError } from '../lib/media-r2'
+import mediaAuditService from './media-audit'
+import { tryTriggerMediaRevalidation } from './media-revalidation'
 
 interface WebsiteRecord {
     id: string
@@ -37,6 +39,11 @@ interface MediaPlacementRecord {
     created_at: string
     updated_at: string
 }
+
+type PlacementAuditAction =
+    | 'placement_assigned'
+    | 'placement_replaced'
+    | 'placement_cleared'
 
 export interface PlacementMediaResponse
     extends Omit<CatalogItemResponse, 'sortOrder'> {}
@@ -84,6 +91,7 @@ export interface AssignPlacementInput {
 export interface ClearPlacementInput {
     websiteSlug: string
     slotKey: string
+    actor?: string
 }
 
 const getWebsiteBySlug = async (
@@ -238,6 +246,75 @@ const mediaById = (
     items: MediaCatalogRecord[]
 ): Map<number, MediaCatalogRecord> =>
     new Map(items.map(item => [item.id, item]))
+
+const auditValuesForPlacement = ({
+    slotKey,
+    placement,
+    media,
+}: {
+    slotKey: string
+    placement?: MediaPlacementRecord | null
+    media?: MediaCatalogRecord | null
+}): Record<string, unknown> => ({
+    slotKey,
+    placementId: placement?.id ?? null,
+    mediaId: media?.id ?? placement?.media_id ?? null,
+    mediaKey: media?.key ?? null,
+    src: media?.src ?? null,
+    filename: media?.filename ?? null,
+    alt: media?.alt ?? null,
+    service: media?.service ?? null,
+    subCategory: media?.sub_category ?? null,
+    aspectRatio: media?.aspect_ratio ?? null,
+    status: media?.status ?? null,
+    updatedBy: placement?.updated_by ?? null,
+})
+
+const queueAuditLog = (
+    input: Parameters<typeof mediaAuditService.tryCreateLog>[0]
+): void => {
+    void mediaAuditService.tryCreateLog(input)
+}
+
+const queuePlacementAuditAndRevalidation = ({
+    websiteSlug,
+    website,
+    slot,
+    action,
+    actor,
+    oldValues,
+    newValues,
+    media,
+}: {
+    websiteSlug: string
+    website: WebsiteRecord
+    slot: MediaPlacementSlot
+    action: PlacementAuditAction
+    actor?: string
+    oldValues: Record<string, unknown> | null
+    newValues: Record<string, unknown> | null
+    media?: MediaCatalogRecord | null
+}): void => {
+    queueAuditLog({
+        websiteId: website.id,
+        clientId: website.client_id,
+        mediaId: media?.id ?? null,
+        mediaKey: media?.key ?? null,
+        action,
+        actor,
+        oldValues,
+        newValues,
+    })
+
+    tryTriggerMediaRevalidation({
+        websiteSlug,
+        reason: action,
+        mediaId: media?.id,
+        mediaKey: media?.key,
+        actor,
+        affectedPaths: slot.affectedPaths,
+    })
+}
 
 const assignmentForSlot = ({
     slot,
@@ -422,6 +499,13 @@ const assignPlacement = async (
         websiteId: website.id,
         slotKey: input.slotKey,
     })
+    const previousMedia =
+        current && current.media_id !== media?.id
+            ? await getMediaForWebsite({
+                  websiteId: website.id,
+                  mediaId: current.media_id,
+              })
+            : null
     const placement = await upsertPlacement({
         website,
         slotKey: input.slotKey,
@@ -429,6 +513,34 @@ const assignPlacement = async (
         actor: input.actor,
         current,
     })
+    const placementAction: PlacementAuditAction | null = !current
+        ? 'placement_assigned'
+        : current.media_id !== input.mediaId
+          ? 'placement_replaced'
+          : null
+
+    if (placementAction) {
+        queuePlacementAuditAndRevalidation({
+            websiteSlug: input.websiteSlug,
+            website,
+            slot,
+            action: placementAction,
+            actor: input.actor,
+            oldValues: current
+                ? auditValuesForPlacement({
+                      slotKey: input.slotKey,
+                      placement: current,
+                      media: previousMedia,
+                  })
+                : null,
+            newValues: auditValuesForPlacement({
+                slotKey: input.slotKey,
+                placement,
+                media,
+            }),
+            media,
+        })
+    }
 
     return assignmentForSlot({
         slot,
@@ -440,7 +552,7 @@ const assignPlacement = async (
 const clearPlacement = async (
     input: ClearPlacementInput
 ): Promise<{ cleared: boolean; slotKey: string }> => {
-    assertValidMediaPlacementSlot({
+    const slot = assertValidMediaPlacementSlot({
         websiteSlug: input.websiteSlug,
         slotKey: input.slotKey,
     })
@@ -454,12 +566,32 @@ const clearPlacement = async (
         return { cleared: false, slotKey: input.slotKey }
     }
 
+    const previousMedia = await getMediaForWebsite({
+        websiteId: website.id,
+        mediaId: current.media_id,
+    })
+
     const { error } = await db
         .from(Tables.MEDIA_PLACEMENTS)
         .delete()
         .eq('id', current.id)
 
     if (error) throw error
+    queuePlacementAuditAndRevalidation({
+        websiteSlug: input.websiteSlug,
+        website,
+        slot,
+        action: 'placement_cleared',
+        actor: input.actor,
+        oldValues: auditValuesForPlacement({
+            slotKey: input.slotKey,
+            placement: current,
+            media: previousMedia,
+        }),
+        newValues: null,
+        media: previousMedia,
+    })
+
     return { cleared: true, slotKey: input.slotKey }
 }
 

--- a/src/services/media-revalidation.ts
+++ b/src/services/media-revalidation.ts
@@ -21,6 +21,9 @@ export type MediaRevalidationReason =
     | 'metadata_edited'
     | 'reorder_changed'
     | 'renamed_moved'
+    | 'placement_assigned'
+    | 'placement_replaced'
+    | 'placement_cleared'
 
 export interface TriggerMediaRevalidationInput {
     websiteSlug: string
@@ -28,6 +31,7 @@ export interface TriggerMediaRevalidationInput {
     mediaId?: number
     mediaKey?: string
     actor?: string
+    affectedPaths?: readonly string[]
 }
 
 export interface MediaRevalidationResult {
@@ -89,15 +93,22 @@ export const buildMediaRevalidationPayload = ({
     mediaId,
     mediaKey,
     actor,
-}: TriggerMediaRevalidationInput): Record<string, unknown> => ({
-    website_slug: websiteSlug,
-    reason,
-    affected_paths: [...MEDIA_REVALIDATION_PATHS],
-    ...(mediaId !== undefined && { media_id: mediaId }),
-    ...(mediaKey && { media_key: mediaKey }),
-    ...(actor && { actor }),
-    triggered_at: new Date().toISOString(),
-})
+    affectedPaths,
+}: TriggerMediaRevalidationInput): Record<string, unknown> => {
+    const paths = affectedPaths?.length
+        ? [...affectedPaths]
+        : [...MEDIA_REVALIDATION_PATHS]
+
+    return {
+        website_slug: websiteSlug,
+        reason,
+        affected_paths: paths,
+        ...(mediaId !== undefined && { media_id: mediaId }),
+        ...(mediaKey && { media_key: mediaKey }),
+        ...(actor && { actor }),
+        triggered_at: new Date().toISOString(),
+    }
+}
 
 export const triggerMediaRevalidation = async (
     input: TriggerMediaRevalidationInput
@@ -113,7 +124,7 @@ export const triggerMediaRevalidation = async (
             skipped: true,
             reason: input.reason,
             website_slug: input.websiteSlug,
-            affected_paths: [...MEDIA_REVALIDATION_PATHS],
+            affected_paths: payload.affected_paths as string[],
             triggered_at: triggeredAt,
         }
     }
@@ -152,7 +163,7 @@ export const triggerMediaRevalidation = async (
             skipped: false,
             reason: input.reason,
             website_slug: input.websiteSlug,
-            affected_paths: [...MEDIA_REVALIDATION_PATHS],
+            affected_paths: payload.affected_paths as string[],
             triggered_at: triggeredAt,
             status: response.status,
         }

--- a/supabase/migrations/20260606223000_add_media_placement_audit_actions.sql
+++ b/supabase/migrations/20260606223000_add_media_placement_audit_actions.sql
@@ -1,0 +1,19 @@
+ALTER TABLE public.media_audit_logs
+DROP CONSTRAINT IF EXISTS media_audit_logs_action_check;
+
+ALTER TABLE public.media_audit_logs
+ADD CONSTRAINT media_audit_logs_action_check CHECK (
+    action IN (
+        'upload_created',
+        'draft_saved',
+        'published',
+        'archived',
+        'restored',
+        'renamed_moved',
+        'metadata_edited',
+        'reorder_changed',
+        'placement_assigned',
+        'placement_replaced',
+        'placement_cleared'
+    )
+);

--- a/test/media-placements-service.test.ts
+++ b/test/media-placements-service.test.ts
@@ -21,7 +21,19 @@ vi.mock('../src/lib/db', () => ({
     },
 }))
 
+vi.mock('../src/services/media-audit', () => ({
+    default: {
+        tryCreateLog: vi.fn(),
+    },
+}))
+
+vi.mock('../src/services/media-revalidation', () => ({
+    tryTriggerMediaRevalidation: vi.fn(),
+}))
+
 import mediaPlacementsService from '../src/services/media-placements'
+import mediaAuditService from '../src/services/media-audit'
+import { tryTriggerMediaRevalidation } from '../src/services/media-revalidation'
 
 const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
     const builder = {
@@ -130,6 +142,8 @@ describe('media placements service', () => {
         })
         process.env.R2_BUCKET_NAME = 'iffers-pictures'
         process.env.R2_PUBLIC_BASE_URL = 'https://env-pub.example.test'
+        vi.mocked(mediaAuditService.tryCreateLog).mockReset()
+        vi.mocked(tryTriggerMediaRevalidation).mockReset()
     })
 
     it('returns public placements backed only by published media', async () => {
@@ -230,14 +244,96 @@ describe('media placements service', () => {
             updated_by: 'jenn@example.com',
         })
         expect(result.assignment?.media.id).toBe(1)
+        expect(mediaAuditService.tryCreateLog).toHaveBeenCalledWith({
+            websiteId: 'website-1',
+            clientId: 'client-1',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            action: 'placement_assigned',
+            actor: 'jenn@example.com',
+            oldValues: null,
+            newValues: expect.objectContaining({
+                slotKey: 'home.hero',
+                placementId: 10,
+                mediaId: 1,
+                mediaKey: 'events/baby-shower/baby.jpg',
+            }),
+        })
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_assigned',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            actor: 'jenn@example.com',
+            affectedPaths: ['/'],
+        })
     })
 
     it('replaces an existing placement row', async () => {
+        const replacementMedia = {
+            ...publishedMedia,
+            id: 4,
+            key: 'events/replacement.jpg',
+            filename: 'replacement.jpg',
+            src: 'https://media.ifferspictures.com/events/replacement.jpg',
+        }
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: replacementMedia, error: null },
+            { data: placement, error: null },
+            { data: publishedMedia, error: null },
+            { data: { ...placement, media_id: 4 }, error: null },
+        ]
+
+        await mediaPlacementsService.assignPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.hero',
+            mediaId: 4,
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.builders[4].update).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            slot_key: 'home.hero',
+            media_id: 4,
+            updated_by: 'jenn@example.com',
+        })
+        expect(mockState.builders[4].eq).toHaveBeenCalledWith('id', 10)
+        expect(mediaAuditService.tryCreateLog).toHaveBeenCalledWith({
+            websiteId: 'website-1',
+            clientId: 'client-1',
+            mediaId: 4,
+            mediaKey: 'events/replacement.jpg',
+            action: 'placement_replaced',
+            actor: 'jenn@example.com',
+            oldValues: expect.objectContaining({
+                slotKey: 'home.hero',
+                mediaId: 1,
+                mediaKey: 'events/baby-shower/baby.jpg',
+            }),
+            newValues: expect.objectContaining({
+                slotKey: 'home.hero',
+                mediaId: 4,
+                mediaKey: 'events/replacement.jpg',
+            }),
+        })
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_replaced',
+            mediaId: 4,
+            mediaKey: 'events/replacement.jpg',
+            actor: 'jenn@example.com',
+            affectedPaths: ['/'],
+        })
+    })
+
+    it('does not audit or revalidate when assigning the same media id again', async () => {
         mockState.queryResults = [
             { data: website, error: null },
             { data: publishedMedia, error: null },
             { data: placement, error: null },
-            { data: { ...placement, media_id: 1 }, error: null },
+            { data: placement, error: null },
         ]
 
         await mediaPlacementsService.assignPlacement({
@@ -247,14 +343,8 @@ describe('media placements service', () => {
             actor: 'jenn@example.com',
         })
 
-        expect(mockState.builders[3].update).toHaveBeenCalledWith({
-            website_id: 'website-1',
-            client_id: 'client-1',
-            slot_key: 'home.hero',
-            media_id: 1,
-            updated_by: 'jenn@example.com',
-        })
-        expect(mockState.builders[3].eq).toHaveBeenCalledWith('id', 10)
+        expect(mediaAuditService.tryCreateLog).not.toHaveBeenCalled()
+        expect(tryTriggerMediaRevalidation).not.toHaveBeenCalled()
     })
 
     it('rejects unknown placement slots before querying Supabase', async () => {
@@ -331,6 +421,7 @@ describe('media placements service', () => {
         mockState.queryResults = [
             { data: website, error: null },
             { data: placement, error: null },
+            { data: publishedMedia, error: null },
             { data: null, error: null },
         ]
 
@@ -340,7 +431,29 @@ describe('media placements service', () => {
         })
 
         expect(result).toEqual({ cleared: true, slotKey: 'home.hero' })
-        expect(mockState.builders[2].delete).toHaveBeenCalled()
-        expect(mockState.builders[2].eq).toHaveBeenCalledWith('id', 10)
+        expect(mockState.builders[3].delete).toHaveBeenCalled()
+        expect(mockState.builders[3].eq).toHaveBeenCalledWith('id', 10)
+        expect(mediaAuditService.tryCreateLog).toHaveBeenCalledWith({
+            websiteId: 'website-1',
+            clientId: 'client-1',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            action: 'placement_cleared',
+            actor: undefined,
+            oldValues: expect.objectContaining({
+                slotKey: 'home.hero',
+                mediaId: 1,
+                mediaKey: 'events/baby-shower/baby.jpg',
+            }),
+            newValues: null,
+        })
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_cleared',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            actor: undefined,
+            affectedPaths: ['/'],
+        })
     })
 })

--- a/test/media-r2.test.ts
+++ b/test/media-r2.test.ts
@@ -8,6 +8,7 @@ import {
     validateUploadInput,
 } from '../src/lib/media-r2'
 import mediaR2Service from '../src/services/media-r2'
+import mediaRevalidationService from '../src/services/media-revalidation'
 
 vi.mock('../src/services/media-r2', () => ({
     default: {
@@ -32,14 +33,24 @@ vi.mock('../src/services/media-placements', () => ({
     },
 }))
 
+vi.mock('../src/services/media-revalidation', () => ({
+    default: {
+        publicCatalogCacheControl: vi.fn(),
+        triggerMediaRevalidation: vi.fn(),
+    },
+}))
+
 const createResponse = () => {
     const res = {
+        set: vi.fn(),
         status: vi.fn(),
         json: vi.fn(),
     }
+    res.set.mockReturnValue(res)
     res.status.mockReturnValue(res)
     res.json.mockReturnValue(res)
     return res as unknown as Response & {
+        set: ReturnType<typeof vi.fn>
         status: ReturnType<typeof vi.fn>
         json: ReturnType<typeof vi.fn>
     }
@@ -120,6 +131,8 @@ describe('media R2 key and upload validation helpers', () => {
 
 describe('media presigned upload controller', () => {
     beforeEach(() => {
+        vi.mocked(mediaR2Service.createPresignedUpload).mockReset()
+        vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockReset()
         vi.mocked(mediaR2Service.createPresignedUpload).mockResolvedValue({
             presigned_url: 'https://signed.example.test/upload',
             public_url:
@@ -183,5 +196,45 @@ describe('media presigned upload controller', () => {
                 }),
             })
         )
+    })
+})
+
+describe('media revalidation controller', () => {
+    beforeEach(() => {
+        vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockReset()
+        vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockResolvedValue({
+            configured: true,
+            triggered: true,
+            skipped: false,
+            reason: 'placement_replaced',
+            website_slug: 'iffers-pictures',
+            affected_paths: ['/'],
+            triggered_at: '2026-06-06T12:00:00.000Z',
+            status: 202,
+        })
+    })
+
+    it('accepts placement-specific manual revalidation reasons', async () => {
+        const res = createResponse()
+
+        await mediaController.revalidateCatalog(
+            createRequest({
+                body: {
+                    reason: 'placement_replaced',
+                    media_id: 123,
+                    media_key: 'events/baby-shower/baby.jpg',
+                },
+            }),
+            res
+        )
+
+        expect(mediaRevalidationService.triggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_replaced',
+            mediaId: 123,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            actor: undefined,
+        })
+        expect(res.status).toHaveBeenCalledWith(200)
     })
 })

--- a/test/media-revalidation.test.ts
+++ b/test/media-revalidation.test.ts
@@ -76,6 +76,37 @@ describe('media revalidation service', () => {
         )
     })
 
+    it('posts placement revalidation payloads with targeted affected paths', async () => {
+        process.env.MEDIA_REVALIDATION_WEBHOOK_URL = webhookUrl
+        mockWebhookResponse(new Response('ok', { status: 202 }))
+
+        const result = await mediaRevalidationService.triggerMediaRevalidation({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_replaced',
+            mediaId: 123,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            affectedPaths: ['/services/events'],
+        })
+
+        const [, init] = vi.mocked(fetch).mock.calls[0]
+        const body = JSON.parse(String((init as RequestInit).body))
+
+        expect(body).toEqual(
+            expect.objectContaining({
+                website_slug: 'iffers-pictures',
+                reason: 'placement_replaced',
+                media_id: 123,
+                media_key: 'events/baby-shower/baby.jpg',
+                affected_paths: ['/services/events'],
+            })
+        )
+        expect(result).toEqual(
+            expect.objectContaining({
+                affected_paths: ['/services/events'],
+            })
+        )
+    })
+
     it('throws a media error when the webhook responds with a failure', async () => {
         process.env.MEDIA_REVALIDATION_WEBHOOK_URL = webhookUrl
         mockWebhookResponse(new Response('invalid token', { status: 401 }))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
         "resolveJsonModule": true,
         "skipLibCheck": true
     },
+    "ts-node": {
+        "files": true
+    },
     "include": ["src/**/*.ts"],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add placement audit actions for assign, replace, and clear mutations
- trigger non-blocking placement revalidation with targeted slot affected paths
- allow placement-specific manual revalidation reasons in the admin revalidation endpoint
- add Supabase migration to extend the media audit action check constraint
- document placement audit and revalidation behavior

## Risks / Follow-up
- Migration must be applied before placement audit rows can be inserted in shared environments.
- Placement revalidation uses slot registry `affectedPaths`; catalog mutations continue to use the existing media-heavy path list.
- Audit and automatic revalidation remain non-blocking; failures are logged and do not roll back completed placement mutations.

## Visual QA
None: backend API, migration, audit, and webhook behavior only.

## Logical QA
- Apply the new Supabase migration and confirm `media_audit_logs_action_check` accepts `placement_assigned`, `placement_replaced`, and `placement_cleared`.
- Assign an empty placement slot and confirm a `placement_assigned` audit row is written with `new_values.slotKey` and the new media metadata.
- Replace an existing placement and confirm a `placement_replaced` audit row includes old/new media metadata.
- Clear an existing placement and confirm a `placement_cleared` audit row includes old placement state and `new_values` is null.
- Confirm placement mutations trigger the frontend revalidation webhook with slot-targeted `affected_paths` from the registry.
- Confirm webhook or audit failures are logged and do not undo the successful placement mutation.
- Confirm `POST /api/media/:websiteSlug/admin/revalidate` accepts placement-specific reasons for manual retry.

## QA Checklist
- Run `npm test`.
- Run `npm run build`.
- Apply `supabase/migrations/20260606223000_add_media_placement_audit_actions.sql` in local/staging before exercising placement writes.
- Use a valid media admin session for placement mutation endpoint checks.
- Use a published media catalog item for assignment/replacement tests.
- Verify affected paths for representative slots: `home.hero` -> `/`, `about.hero` -> `/about`, `services.events.hero` -> `/services/events`.
