### PR TITLE
DEV-953 Add media placement backend tests

### DIFF
--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -135,6 +135,9 @@ router.post(
                 'metadata_edited',
                 'reorder_changed',
                 'renamed_moved',
+                'placement_assigned',
+                'placement_replaced',
+                'placement_cleared',
             ])
             .withMessage('reason must be a valid media revalidation reason'),
         body('media_id')

--- a/test/media-audit.test.ts
+++ b/test/media-audit.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+    from: vi.fn(),
+    insert: vi.fn(),
+}))
+
+vi.mock('../src/lib/db', () => ({
+    db: {
+        from: mockState.from,
+    },
+    Tables: {
+        MEDIA_AUDIT_LOGS: 'media_audit_logs',
+    },
+}))
+
+import mediaAuditService from '../src/services/media-audit'
+
+describe('media audit service', () => {
+    beforeEach(() => {
+        mockState.from.mockReset()
+        mockState.insert.mockReset()
+        mockState.from.mockReturnValue({
+            insert: mockState.insert,
+        })
+    })
+
+    it('writes media audit log rows with placement action payloads', async () => {
+        mockState.insert.mockResolvedValue({ error: null })
+
+        await mediaAuditService.createLog({
+            websiteId: 'website-1',
+            clientId: 'client-1',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            action: 'placement_assigned',
+            actor: 'jenn@example.com',
+            oldValues: null,
+            newValues: {
+                slotKey: 'home.hero',
+                mediaId: 1,
+            },
+        })
+
+        expect(mockState.from).toHaveBeenCalledWith('media_audit_logs')
+        expect(mockState.insert).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            media_id: 1,
+            media_key: 'events/baby-shower/baby.jpg',
+            action: 'placement_assigned',
+            actor: 'jenn@example.com',
+            old_values: null,
+            new_values: {
+                slotKey: 'home.hero',
+                mediaId: 1,
+            },
+        })
+    })
+
+    it('logs and suppresses audit write failures through tryCreateLog', async () => {
+        const error = new Error('audit unavailable')
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        mockState.insert.mockResolvedValue({ error })
+
+        await expect(
+            mediaAuditService.tryCreateLog({
+                websiteId: 'website-1',
+                clientId: 'client-1',
+                mediaId: 1,
+                mediaKey: 'events/baby-shower/baby.jpg',
+                action: 'placement_replaced',
+                oldValues: { slotKey: 'home.hero', mediaId: 1 },
+                newValues: { slotKey: 'home.hero', mediaId: 2 },
+            })
+        ).resolves.toBeUndefined()
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            'Failed to write media audit log for placement_replaced: events/baby-shower/baby.jpg',
+            error
+        )
+    })
+})

--- a/test/media-placements-routes.test.ts
+++ b/test/media-placements-routes.test.ts
@@ -1,0 +1,385 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import mediaRouter from '../src/routes/media'
+import {
+    requireMediaAdminSession,
+    validateRequest,
+} from '../src/routes/middleware'
+import mediaPlacementsService from '../src/services/media-placements'
+import mediaRevalidationService from '../src/services/media-revalidation'
+import { MediaValidationError } from '../src/lib/media-r2'
+
+vi.mock('../src/services/media-admin-auth', () => ({
+    default: {
+        findSessionByHash: vi.fn(),
+        touchSession: vi.fn(),
+    },
+}))
+
+vi.mock('../src/services/media-r2', () => ({
+    default: {
+        createPresignedUpload: vi.fn(),
+        listObjects: vi.fn(),
+        checkDestination: vi.fn(),
+        moveCatalogItemObject: vi.fn(),
+    },
+}))
+
+vi.mock('../src/services/media-catalog', () => ({
+    default: {
+        listCatalog: vi.fn(),
+        createItem: vi.fn(),
+        updateItem: vi.fn(),
+    },
+}))
+
+vi.mock('../src/services/media-placements', () => ({
+    default: {
+        listPublicPlacements: vi.fn(),
+        listAdminPlacements: vi.fn(),
+        assignPlacement: vi.fn(),
+        clearPlacement: vi.fn(),
+    },
+}))
+
+vi.mock('../src/services/media-revalidation', () => ({
+    default: {
+        publicCatalogCacheControl: vi.fn(),
+        triggerMediaRevalidation: vi.fn(),
+    },
+}))
+
+type RouteLayer = {
+    route?: {
+        path: string
+        methods: Record<string, boolean>
+        stack: Array<{ handle: RequestHandler }>
+    }
+}
+
+const routeHandlers = ({
+    path,
+    method,
+}: {
+    path: string
+    method: string
+}): RequestHandler[] => {
+    const layer = (mediaRouter as unknown as { stack: RouteLayer[] }).stack.find(
+        item => item.route?.path === path && item.route.methods[method]
+    )
+
+    if (!layer?.route) {
+        throw new Error(`Route not found: ${method.toUpperCase()} ${path}`)
+    }
+
+    return layer.route.stack.map(item => item.handle)
+}
+
+const createResponse = () => {
+    const headers: Record<string, string> = {}
+    const res = {
+        headers,
+        statusCode: 200,
+        payload: undefined as unknown,
+        set: vi.fn((name: string, value: string) => {
+            headers[name.toLowerCase()] = value
+            return res
+        }),
+        status: vi.fn((statusCode: number) => {
+            res.statusCode = statusCode
+            return res
+        }),
+        json: vi.fn((payload: unknown) => {
+            res.payload = payload
+            return res
+        }),
+    }
+
+    return res as unknown as Response & typeof res
+}
+
+const createRequest = ({
+    params = { websiteSlug: 'iffers-pictures' },
+    body = {},
+}: {
+    params?: Record<string, string>
+    body?: unknown
+}): Request =>
+    ({
+        params,
+        body,
+        query: {},
+        headers: {},
+        get: vi.fn(),
+    }) as unknown as Request
+
+const runHandler = async (
+    handler: RequestHandler,
+    req: Request,
+    res: Response
+): Promise<boolean> => {
+    let nextCalled = false
+    let nextError: unknown
+    const next: NextFunction = (err?: unknown) => {
+        nextCalled = true
+        nextError = err
+    }
+
+    const result = handler(req, res, next)
+    if (result && typeof (result as Promise<unknown>).then === 'function') {
+        await result
+    }
+    if (nextError) throw nextError
+
+    return nextCalled
+}
+
+const runHandlers = async (
+    handlers: RequestHandler[],
+    req: Request,
+    res: Response
+): Promise<void> => {
+    for (const handler of handlers) {
+        const shouldContinue = await runHandler(handler, req, res)
+        if (!shouldContinue) return
+    }
+}
+
+describe('media placement route coverage', () => {
+    beforeEach(() => {
+        vi.mocked(mediaPlacementsService.listPublicPlacements).mockReset()
+        vi.mocked(mediaPlacementsService.assignPlacement).mockReset()
+        vi.mocked(mediaRevalidationService.publicCatalogCacheControl).mockReset()
+        vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockReset()
+        vi.mocked(mediaRevalidationService.publicCatalogCacheControl).mockReturnValue(
+            'public, max-age=60, stale-while-revalidate=300'
+        )
+    })
+
+    it('protects admin placement routes with media admin session middleware', () => {
+        expect(
+            routeHandlers({
+                method: 'get',
+                path: '/api/media/:websiteSlug/admin/placements',
+            })[0]
+        ).toBe(requireMediaAdminSession)
+        expect(
+            routeHandlers({
+                method: 'put',
+                path: '/api/media/:websiteSlug/admin/placements/:slotKey',
+            })[0]
+        ).toBe(requireMediaAdminSession)
+        expect(
+            routeHandlers({
+                method: 'delete',
+                path: '/api/media/:websiteSlug/admin/placements/:slotKey',
+            })[0]
+        ).toBe(requireMediaAdminSession)
+    })
+
+    it('applies public catalog cache headers to public placements controller output', async () => {
+        vi.mocked(mediaPlacementsService.listPublicPlacements).mockResolvedValue({
+            version: 1,
+            publicBaseUrl: 'https://media.ifferspictures.com',
+            placements: [
+                {
+                    slotKey: 'home.hero',
+                    media: {
+                        id: 1,
+                        key: 'events/baby-shower/baby.jpg',
+                        filename: 'baby.jpg',
+                        src: 'https://media.ifferspictures.com/events/baby-shower/baby.jpg',
+                        alt: 'Baby shower detail',
+                        service: 'Events',
+                        subCategory: 'Baby Shower',
+                        aspectRatio: 'portrait',
+                        status: 'published',
+                    },
+                },
+            ],
+        })
+        const req = createRequest({})
+        const res = createResponse()
+
+        await runHandlers(
+            routeHandlers({
+                method: 'get',
+                path: '/api/media/:websiteSlug/placements',
+            }),
+            req,
+            res
+        )
+
+        expect(res.statusCode).toBe(200)
+        expect(res.headers['cache-control']).toBe(
+            'public, max-age=60, stale-while-revalidate=300'
+        )
+        expect(res.payload).toEqual(
+            expect.objectContaining({
+                placements: [
+                    expect.objectContaining({
+                        slotKey: 'home.hero',
+                        media: expect.objectContaining({
+                            id: 1,
+                            subCategory: 'Baby Shower',
+                            aspectRatio: 'portrait',
+                            status: 'published',
+                        }),
+                    }),
+                ],
+            })
+        )
+    })
+
+    it('passes authenticated admin actor context to placement assignment controller', async () => {
+        vi.mocked(mediaPlacementsService.assignPlacement).mockResolvedValue({
+            slotKey: 'home.hero',
+            pageLabel: 'Home',
+            sectionLabel: 'Hero',
+            description: 'Primary homepage hero image.',
+            affectedPaths: ['/'],
+            assignment: {
+                id: 10,
+                updatedBy: 'jenn@example.com',
+                createdAt: '2026-06-07T12:00:00.000Z',
+                updatedAt: '2026-06-07T12:00:00.000Z',
+                media: {
+                    id: 1,
+                    key: 'events/baby-shower/baby.jpg',
+                    filename: 'baby.jpg',
+                    src: 'https://media.ifferspictures.com/events/baby-shower/baby.jpg',
+                    alt: 'Baby shower detail',
+                    service: 'Events',
+                    subCategory: 'Baby Shower',
+                    aspectRatio: 'portrait',
+                    status: 'published',
+                },
+            },
+        })
+        const req = createRequest({
+            params: {
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.hero',
+            },
+            body: { media_id: 1 },
+        })
+        req.mediaAdmin = {
+            email: 'jenn@example.com',
+            sessionId: 'session-1',
+            expiresAt: '2099-01-01T00:00:00.000Z',
+        }
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'put',
+            path: '/api/media/:websiteSlug/admin/placements/:slotKey',
+        })
+
+        await runHandlers(handlers.slice(1), req, res)
+
+        expect(res.statusCode).toBe(200)
+        expect(mediaPlacementsService.assignPlacement).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.hero',
+            mediaId: 1,
+            actor: 'jenn@example.com',
+        })
+    })
+
+    it('returns structured media errors for unknown placement slots', async () => {
+        vi.mocked(mediaPlacementsService.assignPlacement).mockRejectedValue(
+            new MediaValidationError(
+                400,
+                'media.invalid_placement_slot',
+                'Invalid media placement slot.',
+                { slotKey: 'home.unknown' }
+            )
+        )
+        const req = createRequest({
+            params: {
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.unknown',
+            },
+            body: { media_id: 1 },
+        })
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'put',
+            path: '/api/media/:websiteSlug/admin/placements/:slotKey',
+        })
+
+        await runHandlers(handlers.slice(1), req, res)
+
+        expect(res.statusCode).toBe(400)
+        expect(res.payload).toEqual({
+            error: {
+                code: 'media.invalid_placement_slot',
+                message: 'Invalid media placement slot.',
+                details: { slotKey: 'home.unknown' },
+            },
+        })
+    })
+
+    it('accepts placement-specific manual revalidation reasons at route validation', async () => {
+        vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockResolvedValue({
+            configured: true,
+            triggered: true,
+            skipped: false,
+            reason: 'placement_replaced',
+            website_slug: 'iffers-pictures',
+            affected_paths: ['/'],
+            triggered_at: '2026-06-07T12:00:00.000Z',
+            status: 202,
+        })
+        const req = createRequest({
+            body: {
+                reason: 'placement_replaced',
+                media_id: 1,
+                media_key: 'events/baby-shower/baby.jpg',
+            },
+        })
+        req.mediaAdmin = {
+            email: 'jenn@example.com',
+            sessionId: 'session-1',
+            expiresAt: '2099-01-01T00:00:00.000Z',
+        }
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'post',
+            path: '/api/media/:websiteSlug/admin/revalidate',
+        })
+
+        await runHandlers(handlers.slice(1), req, res)
+
+        expect(res.statusCode).toBe(200)
+        expect(mediaRevalidationService.triggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_replaced',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            actor: 'jenn@example.com',
+        })
+    })
+
+    it('rejects unknown manual revalidation reasons before controller execution', async () => {
+        const req = createRequest({
+            body: {
+                reason: 'not_a_reason',
+            },
+        })
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'post',
+            path: '/api/media/:websiteSlug/admin/revalidate',
+        })
+        const validatorsThroughValidateRequest = handlers.slice(
+            1,
+            handlers.indexOf(validateRequest) + 1
+        )
+
+        await runHandlers(validatorsThroughValidateRequest, req, res)
+
+        expect(res.statusCode).toBe(400)
+        expect(mediaRevalidationService.triggerMediaRevalidation).not.toHaveBeenCalled()
+    })
+})

--- a/test/media-placements-service.test.ts
+++ b/test/media-placements-service.test.ts
@@ -189,6 +189,37 @@ describe('media placements service', () => {
         expect(mockState.builders[3].in).toHaveBeenCalledWith('id', [1, 2, 3])
     })
 
+    it('allows one published media item to back multiple public placement slots', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: r2Config, error: null },
+            {
+                data: [
+                    placement,
+                    { ...placement, id: 11, slot_key: 'about.hero', media_id: 1 },
+                ],
+                error: null,
+            },
+            { data: [publishedMedia], error: null },
+        ]
+
+        const result = await mediaPlacementsService.listPublicPlacements({
+            websiteSlug: 'iffers-pictures',
+        })
+
+        expect(result.placements).toEqual([
+            expect.objectContaining({
+                slotKey: 'home.hero',
+                media: expect.objectContaining({ id: 1 }),
+            }),
+            expect.objectContaining({
+                slotKey: 'about.hero',
+                media: expect.objectContaining({ id: 1 }),
+            }),
+        ])
+        expect(mockState.builders[3].in).toHaveBeenCalledWith('id', [1, 1])
+    })
+
     it('returns all admin slots with current assignment metadata', async () => {
         mockState.queryResults = [
             { data: website, error: null },
@@ -417,6 +448,48 @@ describe('media placements service', () => {
         expect(mockState.builders[1].eq).toHaveBeenCalledWith('id', 999)
     })
 
+    it('rejects missing media assignment without audit or revalidation side effects', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: null, error: null },
+        ]
+
+        await expect(
+            mediaPlacementsService.assignPlacement({
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.hero',
+                mediaId: 404,
+            })
+        ).rejects.toMatchObject({
+            status: 404,
+        })
+        expect(mediaAuditService.tryCreateLog).not.toHaveBeenCalled()
+        expect(tryTriggerMediaRevalidation).not.toHaveBeenCalled()
+    })
+
+    it('targets placement revalidation paths from the assigned slot metadata', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: publishedMedia, error: null },
+            { data: null, error: null },
+            { data: { ...placement, slot_key: 'about.hero' }, error: null },
+        ]
+
+        await mediaPlacementsService.assignPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'about.hero',
+            mediaId: 1,
+            actor: 'jenn@example.com',
+        })
+
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith(
+            expect.objectContaining({
+                reason: 'placement_assigned',
+                affectedPaths: ['/about'],
+            })
+        )
+    })
+
     it('clears an existing placement by deleting the row', async () => {
         mockState.queryResults = [
             { data: website, error: null },
@@ -455,5 +528,21 @@ describe('media placements service', () => {
             actor: undefined,
             affectedPaths: ['/'],
         })
+    })
+
+    it('does not audit or revalidate when clearing an empty placement slot', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaPlacementsService.clearPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.hero',
+        })
+
+        expect(result).toEqual({ cleared: false, slotKey: 'home.hero' })
+        expect(mediaAuditService.tryCreateLog).not.toHaveBeenCalled()
+        expect(tryTriggerMediaRevalidation).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Summary
- add focused route-level media placement tests for cache headers, admin route protection, authenticated actor context, structured slot errors, and placement revalidation reasons
- expand media placement service tests for shared media across slots, missing media side-effect safety, slot-targeted revalidation paths, and no-op clear behavior
- add media audit service coverage for placement audit payloads and non-blocking `tryCreateLog` failures
- fix media admin revalidation route validation to accept placement-specific reasons already supported by the controller/service contract

## Risks / Follow-up
- No schema changes in this ticket.
- The route validation fix is runtime-impacting but narrows behavior to the already documented and controller-supported placement revalidation reasons.
- Route tests invoke Express middleware directly rather than opening a local port, so they avoid network listeners and still exercise validation/controller wiring.

## Visual QA
None: backend tests and API validation only.

## Logical QA
- Confirm public placements route coverage asserts public catalog cache headers and render-ready media placement response fields.
- Confirm admin placement route coverage asserts protected-route middleware is wired for list/assign/clear routes.
- Confirm assignment controller coverage passes authenticated admin actor context into the placement service.
- Confirm route validation accepts `placement_assigned`, `placement_replaced`, and `placement_cleared` reasons through the admin revalidation endpoint.
- Confirm service coverage fails if draft/archived/missing/cross-tenant media can leak into assignment or public placement behavior.
- Confirm audit coverage asserts placement audit payloads and non-blocking audit failure handling.

## QA Checklist
- Run `npm test`.
- Run `npm run build`.
- Inspect `test/media-placements-routes.test.ts` for route-level coverage of admin protection and revalidation reason validation.
- Inspect `test/media-placements-service.test.ts` for shared media, missing media, target path, and no-op clear coverage.
- Verify `src/routes/media.ts` manual revalidation reason allowlist includes placement-specific reasons.
