### PR TITLE
DEV-959 Add batch media archive endpoint

### DIFF
--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -68,6 +68,16 @@ const updateCatalogItemSchema = createCatalogItemSchema
         message: 'At least one field is required.',
     })
 
+const batchUpdateCatalogItemsSchema = z
+    .object({
+        ids: z.array(z.number().int().positive()).min(1).max(50),
+        status: z.enum(['archived', 'published', 'draft']),
+    })
+    .refine(value => new Set(value.ids).size === value.ids.length, {
+        message: 'ids must not contain duplicates.',
+        path: ['ids'],
+    })
+
 const assignPlacementSchema = z.object({
     media_id: z.number().int().positive(),
 })
@@ -642,6 +652,45 @@ const updateCatalogItem = async (
     }
 }
 
+const batchUpdateCatalogItems = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    try {
+        const parsed = batchUpdateCatalogItemsSchema.parse(req.body)
+        const result = await mediaCatalogService.batchUpdateItems({
+            websiteSlug: req.params.websiteSlug,
+            ids: parsed.ids,
+            status: parsed.status,
+            actor: req.mediaAdmin?.email,
+        })
+
+        return res.status(200).json(result)
+    } catch (err) {
+        if (err instanceof ZodError) {
+            return sendMediaError(
+                res,
+                400,
+                'media.invalid_payload',
+                'Invalid media catalog batch payload.',
+                err.flatten()
+            )
+        }
+
+        if (err instanceof MediaValidationError) {
+            return sendMediaError(
+                res,
+                err.status,
+                err.code,
+                err.message,
+                err.details
+            )
+        }
+
+        return handleGenericError(err, res)
+    }
+}
+
 export default {
     presignUpload,
     listObjects,
@@ -654,6 +703,7 @@ export default {
     revalidateCatalog,
     createCatalogItem,
     updateCatalogItem,
+    batchUpdateCatalogItems,
     assignPlacement,
     clearPlacement,
 }

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -254,6 +254,29 @@ router.post(
     media.createCatalogItem
 )
 
+router.patch(
+    `${BASE_ROUTE}/:websiteSlug/admin/items/batch`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+        body('ids')
+            .isArray({ min: 1, max: 50 })
+            .withMessage('ids must be a non-empty array of up to 50 items'),
+        body('ids.*')
+            .isInt({ min: 1 })
+            .withMessage('ids must contain positive integers'),
+        body('status')
+            .isIn(['archived', 'published', 'draft'])
+            .withMessage('status must be archived, published, or draft'),
+    ],
+    validateRequest,
+    media.batchUpdateCatalogItems
+)
+
 router.post(
     `${BASE_ROUTE}/:websiteSlug/admin/items/:id/move`,
     requireMediaAdminSession,

--- a/src/services/media-catalog.ts
+++ b/src/services/media-catalog.ts
@@ -107,6 +107,36 @@ export interface UpdateMediaItemInput {
     actor?: string
 }
 
+export interface BatchUpdateMediaItemsInput {
+    websiteSlug: string
+    ids: number[]
+    status: string
+    actor?: string
+}
+
+interface BatchMediaItemError {
+    code: string
+    message: string
+    status: number
+    details?: Record<string, unknown>
+}
+
+export interface BatchMediaItemResult {
+    id: number
+    ok: boolean
+    item?: CatalogItemResponse
+    error?: BatchMediaItemError
+}
+
+export interface BatchUpdateMediaItemsResponse {
+    items: BatchMediaItemResult[]
+    summary: {
+        requested: number
+        succeeded: number
+        failed: number
+    }
+}
+
 const getWebsiteBySlug = async (
     websiteSlug: string
 ): Promise<WebsiteRecord | null> => {
@@ -638,9 +668,16 @@ const getItemForWebsite = async ({
     return data as MediaCatalogRecord | null
 }
 
-const updateItem = async (
-    input: UpdateMediaItemInput
-): Promise<CatalogItemResponse> => {
+interface UpdateMediaItemResult {
+    item: CatalogItemResponse
+    revalidationReason: MediaRevalidationReason | null
+}
+
+const updateItemWithResult = async (
+    input: UpdateMediaItemInput,
+    options: { triggerRevalidation?: boolean } = {}
+): Promise<UpdateMediaItemResult> => {
+    const shouldTriggerRevalidation = options.triggerRevalidation ?? true
     const website = await getWebsiteOrThrow(input.websiteSlug)
     const config = await resolveR2Config(website)
     const current = await getItemForWebsite({ websiteId: website.id, id: input.id })
@@ -825,7 +862,8 @@ const updateItem = async (
     const revalidationReason = revalidationReasonForChanges(auditChanges)
     if (
         revalidationReason &&
-        shouldRevalidatePublicCatalog({ current, updated })
+        shouldRevalidatePublicCatalog({ current, updated }) &&
+        shouldTriggerRevalidation
     ) {
         tryTriggerMediaRevalidation({
             websiteSlug: input.websiteSlug,
@@ -836,11 +874,127 @@ const updateItem = async (
         })
     }
 
-    return toCatalogItemResponse(updated, true)
+    return {
+        item: toCatalogItemResponse(updated, true),
+        revalidationReason:
+            revalidationReason &&
+            shouldRevalidatePublicCatalog({ current, updated })
+                ? revalidationReason
+                : null,
+    }
+}
+
+const updateItem = async (
+    input: UpdateMediaItemInput
+): Promise<CatalogItemResponse> => {
+    const result = await updateItemWithResult(input)
+    return result.item
+}
+
+const batchErrorFor = (err: unknown): BatchMediaItemError => {
+    if (err instanceof MediaValidationError) {
+        return {
+            status: err.status,
+            code: err.code,
+            message: err.message,
+            ...(err.details && { details: err.details }),
+        }
+    }
+
+    if (typeof (err as { status?: unknown })?.status === 'number') {
+        const status = (err as { status: number }).status
+        return {
+            status,
+            code: status === 404 ? 'media.not_found' : 'media.update_failed',
+            message: err instanceof Error ? err.message : 'Media update failed',
+        }
+    }
+
+    return {
+        status: 500,
+        code: 'media.update_failed',
+        message: err instanceof Error ? err.message : 'Media update failed',
+    }
+}
+
+const isExpectedBatchItemError = (err: unknown): boolean =>
+    err instanceof MediaValidationError ||
+    typeof (err as { status?: unknown })?.status === 'number'
+
+const batchRevalidationReason = (
+    reasons: MediaRevalidationReason[]
+): MediaRevalidationReason | null => {
+    const publicReasonPriority: MediaRevalidationReason[] = [
+        'restored',
+        'published',
+        'archived',
+        'renamed_moved',
+        'metadata_edited',
+        'reorder_changed',
+    ]
+
+    return (
+        publicReasonPriority.find(reason => reasons.includes(reason)) || null
+    )
+}
+
+const batchUpdateItems = async (
+    input: BatchUpdateMediaItemsInput
+): Promise<BatchUpdateMediaItemsResponse> => {
+    const items: BatchMediaItemResult[] = []
+    const revalidationReasons: MediaRevalidationReason[] = []
+
+    for (const id of input.ids) {
+        try {
+            const result = await updateItemWithResult(
+                {
+                    websiteSlug: input.websiteSlug,
+                    id,
+                    status: input.status,
+                    actor: input.actor,
+                },
+                { triggerRevalidation: false }
+            )
+
+            items.push({ id, ok: true, item: result.item })
+            if (result.revalidationReason) {
+                revalidationReasons.push(result.revalidationReason)
+            }
+        } catch (err) {
+            if (!isExpectedBatchItemError(err)) throw err
+
+            items.push({
+                id,
+                ok: false,
+                error: batchErrorFor(err),
+            })
+        }
+    }
+
+    const revalidationReason = batchRevalidationReason(revalidationReasons)
+    if (revalidationReason) {
+        tryTriggerMediaRevalidation({
+            websiteSlug: input.websiteSlug,
+            reason: revalidationReason,
+            actor: input.actor,
+        })
+    }
+
+    const succeeded = items.filter(item => item.ok).length
+
+    return {
+        items,
+        summary: {
+            requested: input.ids.length,
+            succeeded,
+            failed: input.ids.length - succeeded,
+        },
+    }
 }
 
 export default {
     listCatalog,
     createItem,
     updateItem,
+    batchUpdateItems,
 }

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -675,6 +675,121 @@ describe('media catalog service', () => {
         )
     })
 
+    it('batch archives media with partial failures and one revalidation', async () => {
+        process.env.MEDIA_REVALIDATION_WEBHOOK_URL =
+            'https://revalidate.example.test/api/revalidate'
+        vi.mocked(fetch).mockResolvedValue(new Response('ok', { status: 200 }))
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: publishedItem, error: null },
+            {
+                data: {
+                    ...publishedItem,
+                    status: 'archived',
+                    archived_at: '2026-05-28T01:00:00.000Z',
+                    archived_by: 'jenn@example.com',
+                    archived_from_status: 'published',
+                },
+                error: null,
+            },
+            { data: null, error: null },
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            {
+                data: {
+                    bucket: 'persisted-bucket',
+                    public_base_url: 'https://pub.example.test',
+                    key_prefix: '',
+                },
+                error: null,
+            },
+            { data: archivedItem, error: null },
+        ]
+
+        const result = await mediaCatalogService.batchUpdateItems({
+            websiteSlug: 'iffers-pictures',
+            ids: [1, 2],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(result.summary).toEqual({
+            requested: 2,
+            succeeded: 1,
+            failed: 1,
+        })
+        expect(result.items[0]).toEqual(
+            expect.objectContaining({
+                id: 1,
+                ok: true,
+                item: expect.objectContaining({
+                    status: 'archived',
+                    archivedBy: 'jenn@example.com',
+                    archivedFromStatus: 'published',
+                }),
+            })
+        )
+        expect(result.items[1]).toEqual(
+            expect.objectContaining({
+                id: 2,
+                ok: false,
+                error: expect.objectContaining({
+                    status: 409,
+                    code: 'media.archived_locked',
+                }),
+            })
+        )
+        expect(mockState.builders[3].update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: 'archived',
+                archived_by: 'jenn@example.com',
+                archived_from_status: 'published',
+            })
+        )
+        expect(mockState.builders[4].insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'archived',
+                actor: 'jenn@example.com',
+                media_id: 1,
+            })
+        )
+        expect(fetch).toHaveBeenCalledTimes(1)
+        const [, init] = vi.mocked(fetch).mock.calls[0]
+        expect(JSON.parse(String((init as RequestInit).body))).toEqual(
+            expect.objectContaining({
+                website_slug: 'iffers-pictures',
+                reason: 'archived',
+                actor: 'jenn@example.com',
+            })
+        )
+        expect(JSON.parse(String((init as RequestInit).body))).not.toHaveProperty(
+            'media_id'
+        )
+    })
+
+    it('rethrows unexpected shared failures during batch archive', async () => {
+        const dbError = new Error('database unavailable')
+        mockState.queryResults = [{ data: null, error: dbError }]
+
+        await expect(
+            mediaCatalogService.batchUpdateItems({
+                websiteSlug: 'iffers-pictures',
+                ids: [1],
+                status: 'archived',
+                actor: 'jenn@example.com',
+            })
+        ).rejects.toBe(dbError)
+    })
+
     it('restores archived media to its previous status and clears archive metadata', async () => {
         mockState.queryResults = [
             { data: { id: 'website-1', client_id: 'client-1' }, error: null },

--- a/test/media-placements-routes.test.ts
+++ b/test/media-placements-routes.test.ts
@@ -6,6 +6,7 @@ import {
     requireMediaAdminSession,
     validateRequest,
 } from '../src/routes/middleware'
+import mediaCatalogService from '../src/services/media-catalog'
 import mediaPlacementsService from '../src/services/media-placements'
 import mediaRevalidationService from '../src/services/media-revalidation'
 import { MediaValidationError } from '../src/lib/media-r2'
@@ -31,6 +32,7 @@ vi.mock('../src/services/media-catalog', () => ({
         listCatalog: vi.fn(),
         createItem: vi.fn(),
         updateItem: vi.fn(),
+        batchUpdateItems: vi.fn(),
     },
 }))
 
@@ -75,6 +77,17 @@ const routeHandlers = ({
 
     return layer.route.stack.map(item => item.handle)
 }
+
+const routeIndex = ({
+    path,
+    method,
+}: {
+    path: string
+    method: string
+}): number =>
+    (mediaRouter as unknown as { stack: RouteLayer[] }).stack.findIndex(
+        item => item.route?.path === path && item.route.methods[method]
+    )
 
 const createResponse = () => {
     const headers: Record<string, string> = {}
@@ -148,6 +161,7 @@ const runHandlers = async (
 
 describe('media placement route coverage', () => {
     beforeEach(() => {
+        vi.mocked(mediaCatalogService.batchUpdateItems).mockReset()
         vi.mocked(mediaPlacementsService.listPublicPlacements).mockReset()
         vi.mocked(mediaPlacementsService.assignPlacement).mockReset()
         vi.mocked(mediaRevalidationService.publicCatalogCacheControl).mockReset()
@@ -176,6 +190,103 @@ describe('media placement route coverage', () => {
                 path: '/api/media/:websiteSlug/admin/placements/:slotKey',
             })[0]
         ).toBe(requireMediaAdminSession)
+    })
+
+    it('registers protected batch media item route before item id patch route', () => {
+        expect(
+            routeHandlers({
+                method: 'patch',
+                path: '/api/media/:websiteSlug/admin/items/batch',
+            })[0]
+        ).toBe(requireMediaAdminSession)
+        expect(
+            routeIndex({
+                method: 'patch',
+                path: '/api/media/:websiteSlug/admin/items/batch',
+            })
+        ).toBeLessThan(
+            routeIndex({
+                method: 'patch',
+                path: '/api/media/:websiteSlug/admin/items/:id',
+            })
+        )
+    })
+
+    it('passes authenticated admin actor context to batch media archive controller', async () => {
+        vi.mocked(mediaCatalogService.batchUpdateItems).mockResolvedValue({
+            items: [
+                {
+                    id: 1,
+                    ok: true,
+                    item: {
+                        id: 1,
+                        key: 'events/baby-shower/baby.jpg',
+                        filename: 'baby.jpg',
+                        src: 'https://media.ifferspictures.com/events/baby-shower/baby.jpg',
+                        alt: 'Baby shower detail',
+                        service: 'Events',
+                        subCategory: 'Baby Shower',
+                        aspectRatio: 'portrait',
+                        status: 'archived',
+                        sortOrder: 0,
+                    },
+                },
+            ],
+            summary: {
+                requested: 1,
+                succeeded: 1,
+                failed: 0,
+            },
+        })
+        const req = createRequest({
+            body: {
+                ids: [1],
+                status: 'archived',
+            },
+        })
+        req.mediaAdmin = {
+            email: 'jenn@example.com',
+            sessionId: 'session-1',
+            expiresAt: '2099-01-01T00:00:00.000Z',
+        }
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'patch',
+            path: '/api/media/:websiteSlug/admin/items/batch',
+        })
+
+        await runHandlers(handlers.slice(1), req, res)
+
+        expect(res.statusCode).toBe(200)
+        expect(mediaCatalogService.batchUpdateItems).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            ids: [1],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+    })
+
+    it('rejects invalid batch media archive payloads before controller execution', async () => {
+        const req = createRequest({
+            body: {
+                ids: [],
+                status: 'archived',
+            },
+        })
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'patch',
+            path: '/api/media/:websiteSlug/admin/items/batch',
+        })
+        const validatorsThroughValidateRequest = handlers.slice(
+            1,
+            handlers.indexOf(validateRequest) + 1
+        )
+
+        await runHandlers(validatorsThroughValidateRequest, req, res)
+
+        expect(res.statusCode).toBe(400)
+        expect(mediaCatalogService.batchUpdateItems).not.toHaveBeenCalled()
     })
 
     it('applies public catalog cache headers to public placements controller output', async () => {


### PR DESCRIPTION
## Summary
- Add protected batch media catalog status endpoint at `PATCH /api/media/:websiteSlug/admin/items/batch`.
- Reuse existing single-item archive/restore rules per item and return partial success results with summary counts.
- Suppress per-item revalidation during batch processing and trigger one media revalidation when successful changes affect public media.
- Add focused service and route tests for batch archive behavior, route order, actor context, validation, audit, and revalidation.

## Risks / Follow-up
- Batch restore supports existing `draft` / `published` status semantics, but the UI should mainly call `archived` for multi-select archive unless restore UI is added.
- Hard delete and R2 object deletion remain intentionally out of scope.

## Visual QA
- None. Server-only API change.

## Logical QA Scenarios
- Authenticated media admin archives multiple published images and receives per-item success records.
- Batch request containing an already archived item reports that item as failed without aborting other items.
- Invalid payloads, empty id lists, oversized id lists, and invalid statuses return structured media API errors.
- Cross-tenant or missing ids are reported as not found/failed without mutation.
- Successful public-affecting batch changes write audit logs and trigger one revalidation webhook.

## QA Checklist
- Call `PATCH /api/media/iffers-pictures/admin/items/batch` with a valid media admin session and `{ "ids": [id1, id2], "status": "archived" }`.
- Confirm the response includes `items` and `summary` with accurate succeeded/failed counts.
- Confirm archived items no longer appear in the public catalog/placements responses.
- Include one already archived id and confirm the valid ids still archive.
- Confirm no R2 objects are deleted.

## Verification
- `npm run build`
- `npm test`