### PR TITLE
Fix media batch archive production timeouts

### DIFF
--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -71,11 +71,7 @@ const updateCatalogItemSchema = createCatalogItemSchema
 const batchUpdateCatalogItemsSchema = z
     .object({
         ids: z.array(z.number().int().positive()).min(1).max(50),
-        status: z.enum(['archived', 'published', 'draft']),
-    })
-    .refine(value => new Set(value.ids).size === value.ids.length, {
-        message: 'ids must not contain duplicates.',
-        path: ['ids'],
+        status: z.enum(['archived']),
     })
 
 const assignPlacementSchema = z.object({
@@ -656,6 +652,10 @@ const batchUpdateCatalogItems = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const startedAt = Date.now()
+    const requestedCount = Array.isArray((req.body as { ids?: unknown })?.ids)
+        ? ((req.body as { ids: unknown[] }).ids.length)
+        : 0
     try {
         const parsed = batchUpdateCatalogItemsSchema.parse(req.body)
         const result = await mediaCatalogService.batchUpdateItems({
@@ -665,8 +665,27 @@ const batchUpdateCatalogItems = async (
             actor: req.mediaAdmin?.email,
         })
 
+        console.info('Media batch catalog update completed', {
+            websiteSlug: req.params.websiteSlug,
+            status: parsed.status,
+            requested: requestedCount,
+            processed: result.summary.requested,
+            succeeded: result.summary.succeeded,
+            failed: result.summary.failed,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+        })
+
         return res.status(200).json(result)
     } catch (err) {
+        console.error('Media batch catalog update failed', {
+            websiteSlug: req.params.websiteSlug,
+            requested: requestedCount,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+            error: err instanceof Error ? err.message : err,
+        })
+
         if (err instanceof ZodError) {
             return sendMediaError(
                 res,

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -270,8 +270,8 @@ router.patch(
             .isInt({ min: 1 })
             .withMessage('ids must contain positive integers'),
         body('status')
-            .isIn(['archived', 'published', 'draft'])
-            .withMessage('status must be archived, published, or draft'),
+            .isIn(['archived'])
+            .withMessage('status must be archived'),
     ],
     validateRequest,
     media.batchUpdateCatalogItems

--- a/src/services/media-catalog.ts
+++ b/src/services/media-catalog.ts
@@ -54,6 +54,10 @@ export interface MediaCatalogRecord {
     archived_from_status: Exclude<MediaStatus, 'archived'> | null
 }
 
+type ArchivableMediaCatalogRecord = MediaCatalogRecord & {
+    status: Exclude<MediaStatus, 'archived'>
+}
+
 export interface CatalogItemResponse {
     id: number
     key: string
@@ -668,6 +672,23 @@ const getItemForWebsite = async ({
     return data as MediaCatalogRecord | null
 }
 
+const getItemsForWebsite = async ({
+    websiteId,
+    ids,
+}: {
+    websiteId: string
+    ids: number[]
+}): Promise<MediaCatalogRecord[]> => {
+    const { data, error } = await db
+        .from(Tables.MEDIA_CATALOG_ITEMS)
+        .select('*')
+        .eq('website_id', websiteId)
+        .in('id', ids)
+
+    if (error) throw error
+    return (data || []) as MediaCatalogRecord[]
+}
+
 interface UpdateMediaItemResult {
     item: CatalogItemResponse
     revalidationReason: MediaRevalidationReason | null
@@ -891,36 +912,6 @@ const updateItem = async (
     return result.item
 }
 
-const batchErrorFor = (err: unknown): BatchMediaItemError => {
-    if (err instanceof MediaValidationError) {
-        return {
-            status: err.status,
-            code: err.code,
-            message: err.message,
-            ...(err.details && { details: err.details }),
-        }
-    }
-
-    if (typeof (err as { status?: unknown })?.status === 'number') {
-        const status = (err as { status: number }).status
-        return {
-            status,
-            code: status === 404 ? 'media.not_found' : 'media.update_failed',
-            message: err instanceof Error ? err.message : 'Media update failed',
-        }
-    }
-
-    return {
-        status: 500,
-        code: 'media.update_failed',
-        message: err instanceof Error ? err.message : 'Media update failed',
-    }
-}
-
-const isExpectedBatchItemError = (err: unknown): boolean =>
-    err instanceof MediaValidationError ||
-    typeof (err as { status?: unknown })?.status === 'number'
-
 const batchRevalidationReason = (
     reasons: MediaRevalidationReason[]
 ): MediaRevalidationReason | null => {
@@ -938,38 +929,177 @@ const batchRevalidationReason = (
     )
 }
 
+const bulkArchiveItems = async ({
+    websiteId,
+    records,
+    actor,
+    archivedAt,
+}: {
+    websiteId: string
+    records: ArchivableMediaCatalogRecord[]
+    actor?: string
+    archivedAt: string
+}): Promise<MediaCatalogRecord[]> => {
+    const statusGroups = records.reduce(
+        (groups, record) => {
+            const group = groups.get(record.status) || []
+            group.push(record.id)
+            groups.set(record.status, group)
+            return groups
+        },
+        new Map<Exclude<MediaStatus, 'archived'>, number[]>()
+    )
+    const updatedRecords: MediaCatalogRecord[] = []
+
+    for (const [archivedFromStatus, ids] of statusGroups.entries()) {
+        const { data, error } = await db
+            .from(Tables.MEDIA_CATALOG_ITEMS)
+            .update({
+                status: 'archived',
+                archived_at: archivedAt,
+                archived_by: actor || null,
+                archived_from_status: archivedFromStatus,
+            })
+            .eq('website_id', websiteId)
+            .in('id', ids)
+            .select('*')
+
+        if (error) throw error
+        updatedRecords.push(...((data || []) as MediaCatalogRecord[]))
+    }
+
+    return updatedRecords
+}
+
+const mediaNotFoundBatchError = (): BatchMediaItemError => ({
+    status: 404,
+    code: 'media.not_found',
+    message: 'Media catalog item not found',
+})
+
+const archivedLockedBatchError = (): BatchMediaItemError => ({
+    status: 409,
+    code: 'media.archived_locked',
+    message: 'Archived media cannot be edited until restored.',
+    details: { status: 'archived' },
+})
+
 const batchUpdateItems = async (
     input: BatchUpdateMediaItemsInput
 ): Promise<BatchUpdateMediaItemsResponse> => {
+    if (input.status !== 'archived') {
+        throw new MediaValidationError(
+            400,
+            'media.invalid_status',
+            'Batch media updates only support archived status.',
+            { status: input.status }
+        )
+    }
+
+    const uniqueIds = [...new Set(input.ids)]
+    const startedAt = Date.now()
+    const website = await getWebsiteOrThrow(input.websiteSlug)
+    const currentRecords = await getItemsForWebsite({
+        websiteId: website.id,
+        ids: uniqueIds,
+    })
+    const currentById = new Map(
+        currentRecords.map(record => [record.id, record])
+    )
+    const eligibleRecords: ArchivableMediaCatalogRecord[] = []
+    uniqueIds.forEach(id => {
+        const record = currentById.get(id)
+        if (record && record.status !== 'archived') {
+            eligibleRecords.push(record as ArchivableMediaCatalogRecord)
+        }
+    })
+
+    const archivedAt = new Date().toISOString()
+    const updatedRecords =
+        eligibleRecords.length > 0
+            ? await bulkArchiveItems({
+                  websiteId: website.id,
+                  records: eligibleRecords,
+                  actor: input.actor,
+                  archivedAt,
+              })
+            : []
+    const updatedById = new Map(
+        updatedRecords.map(record => [record.id, record])
+    )
     const items: BatchMediaItemResult[] = []
     const revalidationReasons: MediaRevalidationReason[] = []
 
-    for (const id of input.ids) {
-        try {
-            const result = await updateItemWithResult(
-                {
-                    websiteSlug: input.websiteSlug,
-                    id,
-                    status: input.status,
-                    actor: input.actor,
-                },
-                { triggerRevalidation: false }
-            )
-
-            items.push({ id, ok: true, item: result.item })
-            if (result.revalidationReason) {
-                revalidationReasons.push(result.revalidationReason)
-            }
-        } catch (err) {
-            if (!isExpectedBatchItemError(err)) throw err
-
+    uniqueIds.forEach(id => {
+        const current = currentById.get(id)
+        if (!current) {
             items.push({
                 id,
                 ok: false,
-                error: batchErrorFor(err),
+                error: mediaNotFoundBatchError(),
             })
+            return
         }
-    }
+
+        if (current.status === 'archived') {
+            items.push({
+                id,
+                ok: false,
+                error: archivedLockedBatchError(),
+            })
+            return
+        }
+
+        const updated = updatedById.get(id)
+        if (!updated) {
+            items.push({
+                id,
+                ok: false,
+                error: {
+                    status: 500,
+                    code: 'media.update_failed',
+                    message: 'Media archive update did not return the updated item.',
+                },
+            })
+            return
+        }
+
+        const oldValues = auditValuesForRecord(current)
+        const newValues = auditValuesForRecord(updated)
+        const auditChanges = determineUpdateAuditChanges({
+            current,
+            updated,
+            oldValues,
+            newValues,
+        })
+
+        auditChanges.forEach(change => {
+            queueAuditLog({
+                websiteId: website.id,
+                clientId: website.client_id,
+                mediaId: updated.id,
+                mediaKey: updated.key,
+                action: change.action,
+                actor: input.actor,
+                oldValues: change.oldValues,
+                newValues: change.newValues,
+            })
+        })
+
+        const revalidationReason = revalidationReasonForChanges(auditChanges)
+        if (
+            revalidationReason &&
+            shouldRevalidatePublicCatalog({ current, updated })
+        ) {
+            revalidationReasons.push(revalidationReason)
+        }
+
+        items.push({
+            id,
+            ok: true,
+            item: toCatalogItemResponse(updated, true),
+        })
+    })
 
     const revalidationReason = batchRevalidationReason(revalidationReasons)
     if (revalidationReason) {
@@ -981,13 +1111,23 @@ const batchUpdateItems = async (
     }
 
     const succeeded = items.filter(item => item.ok).length
+    console.info('Media catalog batch archive service completed', {
+        websiteSlug: input.websiteSlug,
+        requested: input.ids.length,
+        processed: uniqueIds.length,
+        fetched: currentRecords.length,
+        eligible: eligibleRecords.length,
+        succeeded,
+        failed: uniqueIds.length - succeeded,
+        durationMs: Date.now() - startedAt,
+    })
 
     return {
         items,
         summary: {
-            requested: input.ids.length,
+            requested: uniqueIds.length,
             succeeded,
-            failed: input.ids.length - succeeded,
+            failed: uniqueIds.length - succeeded,
         },
     }
 }

--- a/test/media-catalog.test.ts
+++ b/test/media-catalog.test.ts
@@ -28,6 +28,7 @@ const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
         select: vi.fn(),
         eq: vi.fn(),
         is: vi.fn(),
+        in: vi.fn(),
         neq: vi.fn(),
         order: vi.fn(),
         insert: vi.fn(),
@@ -40,6 +41,7 @@ const makeQueryBuilder = (result: { data: unknown; error: unknown }) => {
     builder.select.mockReturnValue(builder)
     builder.eq.mockReturnValue(builder)
     builder.is.mockReturnValue(builder)
+    builder.in.mockReturnValue(builder)
     builder.neq.mockReturnValue(builder)
     builder.order.mockReturnValue(builder)
     builder.insert.mockReturnValue(builder)
@@ -681,36 +683,23 @@ describe('media catalog service', () => {
         vi.mocked(fetch).mockResolvedValue(new Response('ok', { status: 200 }))
         mockState.queryResults = [
             { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            { data: [publishedItem, archivedItem], error: null },
             {
-                data: {
-                    bucket: 'persisted-bucket',
-                    public_base_url: 'https://pub.example.test',
-                    key_prefix: '',
-                },
-                error: null,
-            },
-            { data: publishedItem, error: null },
-            {
-                data: {
+                data: [
+                    {
                     ...publishedItem,
                     status: 'archived',
                     archived_at: '2026-05-28T01:00:00.000Z',
                     archived_by: 'jenn@example.com',
                     archived_from_status: 'published',
-                },
+                    },
+                ],
                 error: null,
             },
-            { data: null, error: null },
-            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
             {
-                data: {
-                    bucket: 'persisted-bucket',
-                    public_base_url: 'https://pub.example.test',
-                    key_prefix: '',
-                },
+                data: null,
                 error: null,
             },
-            { data: archivedItem, error: null },
         ]
 
         const result = await mediaCatalogService.batchUpdateItems({
@@ -748,14 +737,16 @@ describe('media catalog service', () => {
                 }),
             })
         )
-        expect(mockState.builders[3].update).toHaveBeenCalledWith(
+        expect(mockState.builders[1].in).toHaveBeenCalledWith('id', [1, 2])
+        expect(mockState.builders[2].update).toHaveBeenCalledWith(
             expect.objectContaining({
                 status: 'archived',
                 archived_by: 'jenn@example.com',
                 archived_from_status: 'published',
             })
         )
-        expect(mockState.builders[4].insert).toHaveBeenCalledWith(
+        expect(mockState.builders[2].in).toHaveBeenCalledWith('id', [1])
+        expect(mockState.builders[3].insert).toHaveBeenCalledWith(
             expect.objectContaining({
                 action: 'archived',
                 actor: 'jenn@example.com',
@@ -774,6 +765,235 @@ describe('media catalog service', () => {
         expect(JSON.parse(String((init as RequestInit).body))).not.toHaveProperty(
             'media_id'
         )
+    })
+
+    it('batch archives multiple published images in one grouped update', async () => {
+        const secondPublishedItem = {
+            ...publishedItem,
+            id: 4,
+            key: 'events/baby-shower/second.jpg',
+            filename: 'second.jpg',
+            src: 'https://pub.example.test/events/baby-shower/second.jpg',
+        }
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            { data: [publishedItem, secondPublishedItem], error: null },
+            {
+                data: [
+                    {
+                        ...publishedItem,
+                        status: 'archived',
+                        archived_at: '2026-05-28T01:00:00.000Z',
+                        archived_by: 'jenn@example.com',
+                        archived_from_status: 'published',
+                    },
+                    {
+                        ...secondPublishedItem,
+                        status: 'archived',
+                        archived_at: '2026-05-28T01:00:00.000Z',
+                        archived_by: 'jenn@example.com',
+                        archived_from_status: 'published',
+                    },
+                ],
+                error: null,
+            },
+            { data: null, error: null },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaCatalogService.batchUpdateItems({
+            websiteSlug: 'iffers-pictures',
+            ids: [1, 4],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+
+        expect(result.summary).toEqual({
+            requested: 2,
+            succeeded: 2,
+            failed: 0,
+        })
+        expect(result.items).toEqual([
+            expect.objectContaining({ id: 1, ok: true }),
+            expect.objectContaining({ id: 4, ok: true }),
+        ])
+        expect(mockState.builders[1].in).toHaveBeenCalledWith('id', [1, 4])
+        expect(mockState.builders[2].in).toHaveBeenCalledWith('id', [1, 4])
+    })
+
+    it('deduplicates batch archive ids before querying or updating', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            { data: [publishedItem], error: null },
+            {
+                data: [
+                    {
+                        ...publishedItem,
+                        status: 'archived',
+                        archived_at: '2026-05-28T01:00:00.000Z',
+                        archived_by: 'jenn@example.com',
+                        archived_from_status: 'published',
+                    },
+                ],
+                error: null,
+            },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaCatalogService.batchUpdateItems({
+            websiteSlug: 'iffers-pictures',
+            ids: [1, 1, 1],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+
+        expect(result.summary).toEqual({
+            requested: 1,
+            succeeded: 1,
+            failed: 0,
+        })
+        expect(result.items).toHaveLength(1)
+        expect(mockState.builders[1].in).toHaveBeenCalledWith('id', [1])
+        expect(mockState.builders[2].in).toHaveBeenCalledWith('id', [1])
+    })
+
+    it('returns not found per-item failures in batch archive responses', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            { data: [publishedItem], error: null },
+            {
+                data: [
+                    {
+                        ...publishedItem,
+                        status: 'archived',
+                        archived_at: '2026-05-28T01:00:00.000Z',
+                        archived_by: 'jenn@example.com',
+                        archived_from_status: 'published',
+                    },
+                ],
+                error: null,
+            },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaCatalogService.batchUpdateItems({
+            websiteSlug: 'iffers-pictures',
+            ids: [1, 99],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+
+        expect(result.summary).toEqual({
+            requested: 2,
+            succeeded: 1,
+            failed: 1,
+        })
+        expect(result.items[1]).toEqual({
+            id: 99,
+            ok: false,
+            error: {
+                status: 404,
+                code: 'media.not_found',
+                message: 'Media catalog item not found',
+            },
+        })
+    })
+
+    it('rejects unsupported batch statuses', async () => {
+        await expect(
+            mediaCatalogService.batchUpdateItems({
+                websiteSlug: 'iffers-pictures',
+                ids: [1],
+                status: 'published',
+                actor: 'jenn@example.com',
+            })
+        ).rejects.toMatchObject({
+            status: 400,
+            code: 'media.invalid_status',
+        })
+        expect(mockState.from).not.toHaveBeenCalled()
+    })
+
+    it('does not query R2 config or objects during batch archive', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            { data: [publishedItem], error: null },
+            {
+                data: [
+                    {
+                        ...publishedItem,
+                        status: 'archived',
+                        archived_at: '2026-05-28T01:00:00.000Z',
+                        archived_by: 'jenn@example.com',
+                        archived_from_status: 'published',
+                    },
+                ],
+                error: null,
+            },
+            { data: null, error: null },
+        ]
+
+        await mediaCatalogService.batchUpdateItems({
+            websiteSlug: 'iffers-pictures',
+            ids: [1],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.from).not.toHaveBeenCalledWith('media_r2_configs')
+    })
+
+    it('response shape matches the frontend batch archive contract', async () => {
+        mockState.queryResults = [
+            { data: { id: 'website-1', client_id: 'client-1' }, error: null },
+            { data: [publishedItem], error: null },
+            {
+                data: [
+                    {
+                        ...publishedItem,
+                        status: 'archived',
+                        archived_at: '2026-05-28T01:00:00.000Z',
+                        archived_by: 'jenn@example.com',
+                        archived_from_status: 'published',
+                    },
+                ],
+                error: null,
+            },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaCatalogService.batchUpdateItems({
+            websiteSlug: 'iffers-pictures',
+            ids: [1],
+            status: 'archived',
+            actor: 'jenn@example.com',
+        })
+
+        expect(result).toEqual({
+            items: [
+                {
+                    id: 1,
+                    ok: true,
+                    item: expect.objectContaining({
+                        id: 1,
+                        key: 'events/baby-shower/baby.jpg',
+                        filename: 'baby.jpg',
+                        src: 'https://pub.example.test/events/baby-shower/baby.jpg',
+                        alt: 'Mother-to-be opening gifts',
+                        service: 'Events',
+                        subCategory: 'Baby Shower',
+                        aspectRatio: 'portrait',
+                        status: 'archived',
+                        sortOrder: 0,
+                    }),
+                },
+            ],
+            summary: {
+                requested: 1,
+                succeeded: 1,
+                failed: 0,
+            },
+        })
     })
 
     it('rethrows unexpected shared failures during batch archive', async () => {

--- a/test/media-placements-routes.test.ts
+++ b/test/media-placements-routes.test.ts
@@ -289,6 +289,52 @@ describe('media placement route coverage', () => {
         expect(mediaCatalogService.batchUpdateItems).not.toHaveBeenCalled()
     })
 
+    it('rejects batch media archive requests with more than 50 ids', async () => {
+        const req = createRequest({
+            body: {
+                ids: Array.from({ length: 51 }, (_, index) => index + 1),
+                status: 'archived',
+            },
+        })
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'patch',
+            path: '/api/media/:websiteSlug/admin/items/batch',
+        })
+        const validatorsThroughValidateRequest = handlers.slice(
+            1,
+            handlers.indexOf(validateRequest) + 1
+        )
+
+        await runHandlers(validatorsThroughValidateRequest, req, res)
+
+        expect(res.statusCode).toBe(400)
+        expect(mediaCatalogService.batchUpdateItems).not.toHaveBeenCalled()
+    })
+
+    it('rejects unsupported batch media statuses before controller execution', async () => {
+        const req = createRequest({
+            body: {
+                ids: [1],
+                status: 'published',
+            },
+        })
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'patch',
+            path: '/api/media/:websiteSlug/admin/items/batch',
+        })
+        const validatorsThroughValidateRequest = handlers.slice(
+            1,
+            handlers.indexOf(validateRequest) + 1
+        )
+
+        await runHandlers(validatorsThroughValidateRequest, req, res)
+
+        expect(res.statusCode).toBe(400)
+        expect(mediaCatalogService.batchUpdateItems).not.toHaveBeenCalled()
+    })
+
     it('applies public catalog cache headers to public placements controller output', async () => {
         vi.mocked(mediaPlacementsService.listPublicPlacements).mockResolvedValue({
             version: 1,


### PR DESCRIPTION
## Summary
- Optimize `PATCH /api/media/:websiteSlug/admin/items/batch` for archive-only production batches.
- Replace serial per-item archive work with one tenant-scoped bulk fetch and grouped bulk archive updates.
- Deduplicate IDs server-side and return one consolidated partial-success response.
- Add endpoint/service timing logs for production diagnostics.
- Restrict batch status to `archived`; hard delete/R2 object deletion remains out of scope.

## Behavior
- Accepts one request containing up to 50 IDs.
- Deduplicates IDs before processing.
- Returns HTTP 200 with per-item results for valid requests, including partial failures.
- Returns 400 for invalid request shape, unsupported status, empty IDs, or more than 50 IDs.
- Preserves `archived_from_status` by grouping updates by previous status.
- Queues audit logs per successfully archived item.
- Triggers one media revalidation for public-affecting successful archive changes.

## Production Fix
The previous implementation called the single-item update path serially for every ID. Each item repeated website/config/item/update/audit work, which could exceed Cloudflare/proxy timeouts for larger batches. This version avoids serial N+1 reads and updates by bulk-fetching records and bulk-updating eligible archive rows in bounded status groups.

## QA Checklist
- Batch archive one published image.
- Batch archive multiple published images in one request.
- Include duplicate IDs and confirm they are processed once.
- Include an already archived item and confirm a per-item `media.archived_locked` failure.
- Include a missing ID and confirm a per-item `media.not_found` failure.
- Confirm requests with more than 50 IDs return 400.
- Confirm unsupported statuses return 400.
- Confirm archive does not delete any R2 objects.
- Confirm public catalog/placement rendering no longer includes successfully archived media.

## Verification
- `npm run build`
- `npm test -- media-catalog media-placements-routes`
- `npm test`
