### PR TITLE
DEV-1020 Stabilize media upload handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `/api/media/:websiteSlug/admin/revalidate` | POST | Trigger the configured frontend cache revalidation webhook for public media pages. | `controllers/media.revalidateCatalog` |
 | `/api/media/:websiteSlug/admin/objects/check-destination` | POST | Check catalog and R2 destination collisions before moving media. | `controllers/media.checkDestination` |
 | `/api/media/:websiteSlug/admin/items` | POST | Create a draft media catalog item after upload. | `controllers/media.createCatalogItem` |
+| `/api/media/:websiteSlug/admin/items/batch` | POST | Create multiple draft media catalog items after direct uploads and return per-file success/failure results. | `controllers/media.batchCreateCatalogItems` |
 | `/api/media/:websiteSlug/admin/items/:id/move` | POST | Safely move/rename a draft R2 object and update its catalog record. | `controllers/media.moveCatalogItem` |
 | `/api/media/:websiteSlug/admin/items/:id` | PATCH | Update safe media catalog metadata for authenticated media admins. | `controllers/media.updateCatalogItem` |
 | `/api/media/:websiteSlug/admin/uploads/presign` | POST | Create a protected, short-lived Cloudflare R2 direct-upload URL. | `controllers/media.presignUpload` |
@@ -127,7 +128,10 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `R2_BUCKET_NAME` | Fallback Cloudflare R2 bucket name for media manager features when no per-client config exists. |
 | `R2_PUBLIC_BASE_URL` | Fallback public base URL for R2 media objects when no per-client config exists. |
 | `R2_PRESIGN_EXPIRES_SECONDS` | Optional R2 presigned upload expiry; defaults to 900 seconds. |
+| `R2_CONNECTION_TIMEOUT_MS` | Optional R2 S3 connection timeout; defaults to 2000ms. |
+| `R2_REQUEST_TIMEOUT_MS` | Optional R2 S3 request timeout; defaults to 8000ms. |
 | `MEDIA_MAX_UPLOAD_BYTES` | Optional maximum media upload size; defaults to 10MB. |
+| `MEDIA_UPLOAD_BATCH_MAX_ITEMS` | Optional maximum batch draft-completion item count; defaults to 10. |
 | `MEDIA_ADMIN_EMAILS` | Comma-separated approved media manager admin email addresses. |
 | `MEDIA_ADMIN_APP_BASE_URL` | Frontend base URL used when generating media admin magic links. |
 | `MEDIA_ADMIN_MAGIC_LINK_TTL_MINUTES` | Optional magic-link expiry window; defaults to 15 minutes. |

--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -315,7 +315,8 @@ Response:
   "presigned_url": "https://...",
   "public_url": "https://pub.example.r2.dev/events/baby-shower/1712345678-baby-shower-15.jpg",
   "r2_key": "events/baby-shower/1712345678-baby-shower-15.jpg",
-  "expires_at": "2026-05-31T12:15:00.000Z"
+  "expires_at": "2026-05-31T12:15:00.000Z",
+  "request_id": "1d462f43-2d43-4a5a-94c5-3be6b1279d1c"
 }
 ```
 
@@ -363,6 +364,98 @@ Site image draft example:
 
 Site images use the same bucket and public base URL. Recommended folders are
 `site/home/`, `site/about/`, `site/brand/`, and `site/misc/`.
+
+## Complete Uploaded Drafts In Batch
+
+`POST /api/media/:websiteSlug/admin/items/batch`
+
+Protected. Call this after one or more direct R2 PUTs succeed when the frontend
+wants one response that preserves per-file partial success and failure state.
+The endpoint creates catalog draft records sequentially and does not roll back
+successful files when a later file fails.
+
+Request:
+
+```json
+{
+  "items": [
+    {
+      "key": "events/baby-shower/1712345678-baby-shower-15.jpg",
+      "filename": "baby-shower-15.jpg",
+      "src": "https://pub.example.r2.dev/events/baby-shower/1712345678-baby-shower-15.jpg",
+      "alt": "",
+      "library": "portfolio",
+      "service": null,
+      "subCategory": null,
+      "aspectRatio": null,
+      "sortOrder": 0
+    }
+  ]
+}
+```
+
+Response when every draft is created:
+
+```json
+{
+  "request_id": "1d462f43-2d43-4a5a-94c5-3be6b1279d1c",
+  "status": "completed",
+  "items": [
+    {
+      "index": 0,
+      "key": "events/baby-shower/1712345678-baby-shower-15.jpg",
+      "ok": true,
+      "item": {
+        "id": 123,
+        "key": "events/baby-shower/1712345678-baby-shower-15.jpg",
+        "status": "draft"
+      }
+    }
+  ],
+  "summary": {
+    "requested": 1,
+    "succeeded": 1,
+    "failed": 0
+  }
+}
+```
+
+Response when some files fail uses HTTP `207` and preserves created drafts:
+
+```json
+{
+  "request_id": "1d462f43-2d43-4a5a-94c5-3be6b1279d1c",
+  "status": "partial_success",
+  "items": [
+    {
+      "index": 0,
+      "key": "events/baby-shower/one.jpg",
+      "ok": true,
+      "item": {
+        "id": 123,
+        "key": "events/baby-shower/one.jpg",
+        "status": "draft"
+      }
+    },
+    {
+      "index": 1,
+      "key": "events/baby-shower/two.jpg",
+      "ok": false,
+      "error": {
+        "status": 503,
+        "code": "media.upload_temporary_unavailable",
+        "message": "Media storage is temporarily busy. Retry this upload shortly.",
+        "retryable": true
+      }
+    }
+  ],
+  "summary": {
+    "requested": 2,
+    "succeeded": 1,
+    "failed": 1
+  }
+}
+```
 
 ## Update Metadata, Publish, Archive, Restore, Reorder
 
@@ -684,7 +777,10 @@ Server runtime:
 | `R2_BUCKET_NAME` | fallback | Fallback bucket when no per-client config exists. |
 | `R2_PUBLIC_BASE_URL` | fallback | Fallback public object base URL. |
 | `R2_PRESIGN_EXPIRES_SECONDS` | no | Presign expiry. Defaults to `900`. |
+| `R2_CONNECTION_TIMEOUT_MS` | no | R2 S3 connection timeout. Defaults to `2000`. |
+| `R2_REQUEST_TIMEOUT_MS` | no | R2 S3 request timeout. Defaults to `8000`. |
 | `MEDIA_MAX_UPLOAD_BYTES` | no | Max upload size. Defaults to 10 MB. |
+| `MEDIA_UPLOAD_BATCH_MAX_ITEMS` | no | Max batch draft-completion items. Defaults to `10`. |
 | `MEDIA_REVALIDATION_WEBHOOK_URL` | no | Frontend revalidation webhook. |
 | `MEDIA_REVALIDATION_SECRET` | no | Optional webhook bearer token. |
 | `MEDIA_REVALIDATION_TIMEOUT_MS` | no | Webhook timeout. Defaults to `5000`. |
@@ -708,9 +804,19 @@ Upload:
 
 1. Request a presigned URL.
 2. PUT the file directly to R2 with the returned URL.
-3. Create a draft catalog item with `key: r2_key` and `src: public_url`.
+3. Create a draft catalog item with `key: r2_key` and `src: public_url`, or call
+   batch draft completion after several direct PUTs succeed.
 4. Let Jenn fill alt/category/aspect metadata.
 5. Publish with `status: "published"` after required metadata is present.
+
+Upload-related retryable server error codes:
+
+| Code | HTTP | Meaning |
+| --- | --- | --- |
+| `media.upload_timeout` | `504` | R2/provider operation timed out. Retry the affected file. |
+| `media.upload_temporary_unavailable` | `503` | R2/provider reported temporary pressure or rate limiting. Retry after a short delay. |
+| `media.upload_provider_error` | `502` | R2/provider failed without a more specific timeout/busy signal. Retryable. |
+| `media.upload_catalog_create_failed` | `500` | The object may be in R2, but the draft catalog row failed. Refresh catalog and retry draft completion for that file. |
 
 Rename or move draft media:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
                 "zod": "^3.23.8",
                 "cookie": "^0.7.2",
                 "@aws-sdk/client-s3": "^3.1055.0",
-                "@aws-sdk/s3-request-presigner": "^3.1055.0"
+                "@aws-sdk/s3-request-presigner": "^3.1055.0",
+                "@smithy/node-http-handler": "^4.7.3"
             },
             "devDependencies": {
                 "@types/cors": "^2.8.17",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.1055.0",
         "@aws-sdk/s3-request-presigner": "^3.1055.0",
+        "@smithy/node-http-handler": "^4.7.3",
         "@supabase/supabase-js": "^2.45.4",
         "bcryptjs": "^2.4.3",
         "cookie": "^0.7.2",

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -1,11 +1,16 @@
 import { Request, Response } from 'express'
+import crypto from 'crypto'
 import { z, ZodError } from 'zod'
 
 import mediaCatalogService from '../services/media-catalog'
 import mediaPlacementsService from '../services/media-placements'
 import mediaR2Service from '../services/media-r2'
 import mediaRevalidationService from '../services/media-revalidation'
-import { MediaValidationError } from '../lib/media-r2'
+import {
+    mediaUploadBatchMaxItems,
+    MediaOperationError,
+    MediaValidationError,
+} from '../lib/media-r2'
 import { handleGenericError } from '../utils/http'
 
 const presignUploadSchema = z.object({
@@ -61,6 +66,10 @@ const createCatalogItemSchema = z.object({
     sortOrder: z.number().int().min(0).optional(),
 })
 
+const batchCreateCatalogItemsSchema = z.object({
+    items: z.array(z.unknown()).min(1).max(mediaUploadBatchMaxItems()),
+})
+
 const updateCatalogItemSchema = createCatalogItemSchema
     .partial()
     .extend({
@@ -85,20 +94,147 @@ const sendMediaError = (
     status: number,
     code: string,
     message: string,
-    details?: Record<string, unknown>
+    details?: Record<string, unknown>,
+    options?: {
+        requestId?: string
+        retryable?: boolean
+    }
 ): Response =>
     res.status(status).json({
         error: {
             code,
             message,
+            ...(options?.requestId && { request_id: options.requestId }),
+            ...(options?.retryable !== undefined && {
+                retryable: options.retryable,
+            }),
             ...(details && { details }),
         },
     })
+
+interface MediaErrorPayload {
+    status: number
+    code: string
+    message: string
+    details?: Record<string, unknown>
+    retryable?: boolean
+}
+
+const requestIdFor = (req: Request): string => {
+    const header = req.headers?.['x-request-id']
+    return typeof header === 'string' && header.trim()
+        ? header.trim()
+        : crypto.randomUUID()
+}
+
+const logMediaEvent = (
+    level: 'info' | 'warn' | 'error',
+    event: string,
+    fields: Record<string, unknown>
+): void => {
+    console[level](`Media upload ${event}`, fields)
+}
+
+const knownMediaError = (
+    err: unknown,
+    fallbackCodes: {
+        notFound: string
+        unavailable?: string
+    }
+): MediaErrorPayload | null => {
+    if (err instanceof MediaValidationError) {
+        return {
+            status: err.status,
+            code: err.code,
+            message: err.message,
+            details: err.details,
+            retryable: false,
+        }
+    }
+
+    if (err instanceof MediaOperationError) {
+        return {
+            status: err.status,
+            code: err.code,
+            message: err.message,
+            details: err.details,
+            retryable: err.retryable,
+        }
+    }
+
+    if (typeof (err as { status?: unknown })?.status === 'number') {
+        const status = (err as { status: number }).status
+        return {
+            status,
+            message: err instanceof Error ? err.message : 'Media request failed',
+            code:
+                status === 404
+                    ? fallbackCodes.notFound
+                    : fallbackCodes.unavailable || 'media.r2_not_configured',
+            retryable: status >= 500,
+        }
+    }
+
+    return null
+}
+
+const sendKnownMediaError = (
+    res: Response,
+    err: unknown,
+    requestId: string,
+    fallbackCodes: {
+        notFound: string
+        unavailable?: string
+    }
+): Response | null => {
+    const payload = knownMediaError(err, fallbackCodes)
+    if (!payload) return null
+
+    return sendMediaError(
+        res,
+        payload.status,
+        payload.code,
+        payload.message,
+        payload.details,
+        { requestId, retryable: payload.retryable }
+    )
+}
+
+const batchErrorFrom = (
+    err: unknown,
+    fallbackCodes: {
+        notFound: string
+        unavailable?: string
+    }
+): MediaErrorPayload => {
+    if (err instanceof ZodError) {
+        return {
+            status: 400,
+            code: 'media.invalid_payload',
+            message: 'Invalid media catalog item payload.',
+            details: err.flatten(),
+            retryable: false,
+        }
+    }
+
+    return (
+        knownMediaError(err, fallbackCodes) || {
+            status: 500,
+            code: 'media.upload_catalog_create_failed',
+            message: 'Media catalog item could not be created after upload.',
+            retryable: true,
+        }
+    )
+}
 
 const presignUpload = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const startedAt = Date.now()
+    const requestId = requestIdFor(req)
+    res.set('X-Request-Id', requestId)
+
     try {
         const { websiteSlug } = req.params
         const parsed = presignUploadSchema.parse(req.body)
@@ -110,39 +246,53 @@ const presignUpload = async (
             size: parsed.size,
         })
 
-        return res.status(200).json(result)
+        logMediaEvent('info', 'presign_completed', {
+            requestId,
+            websiteSlug,
+            filename: parsed.filename,
+            contentType: parsed.content_type,
+            size: parsed.size,
+            r2Key: result.r2_key,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+        })
+
+        return res.status(200).json({
+            ...result,
+            request_id: requestId,
+        })
     } catch (err) {
+        logMediaEvent('error', 'presign_failed', {
+            requestId,
+            websiteSlug: req.params.websiteSlug,
+            filename:
+                typeof (req.body as { filename?: unknown })?.filename === 'string'
+                    ? (req.body as { filename: string }).filename
+                    : undefined,
+            size:
+                typeof (req.body as { size?: unknown })?.size === 'number'
+                    ? (req.body as { size: number }).size
+                    : undefined,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+            error: err instanceof Error ? err.message : err,
+        })
+
         if (err instanceof ZodError) {
             return sendMediaError(
                 res,
                 400,
                 'media.invalid_payload',
                 'Invalid upload presign payload.',
-                err.flatten()
+                err.flatten(),
+                { requestId, retryable: false }
             )
         }
 
-        if (err instanceof MediaValidationError) {
-            return sendMediaError(
-                res,
-                err.status,
-                err.code,
-                err.message,
-                err.details
-            )
-        }
-
-        if (typeof (err as { status?: unknown })?.status === 'number') {
-            const status = (err as { status: number }).status
-            const message =
-                err instanceof Error ? err.message : 'Media request failed'
-            const code =
-                status === 404
-                    ? 'media.website_not_found'
-                    : 'media.r2_not_configured'
-
-            return sendMediaError(res, status, code, message)
-        }
+        const knownErrorResponse = sendKnownMediaError(res, err, requestId, {
+            notFound: 'media.website_not_found',
+        })
+        if (knownErrorResponse) return knownErrorResponse
 
         return handleGenericError(err, res)
     }
@@ -152,6 +302,7 @@ const listObjects = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const requestId = requestIdFor(req)
     try {
         const prefix =
             typeof req.query.prefix === 'string' ? req.query.prefix : undefined
@@ -173,17 +324,10 @@ const listObjects = async (
             )
         }
 
-        if (typeof (err as { status?: unknown })?.status === 'number') {
-            const status = (err as { status: number }).status
-            const message =
-                err instanceof Error ? err.message : 'Media request failed'
-            const code =
-                status === 404
-                    ? 'media.website_not_found'
-                    : 'media.r2_not_configured'
-
-            return sendMediaError(res, status, code, message)
-        }
+        const knownErrorResponse = sendKnownMediaError(res, err, requestId, {
+            notFound: 'media.website_not_found',
+        })
+        if (knownErrorResponse) return knownErrorResponse
 
         return handleGenericError(err, res)
     }
@@ -193,6 +337,7 @@ const checkDestination = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const requestId = requestIdFor(req)
     try {
         const parsed = checkDestinationSchema.parse(req.body)
         const result = await mediaR2Service.checkDestination({
@@ -209,31 +354,15 @@ const checkDestination = async (
                 400,
                 'media.invalid_payload',
                 'Invalid destination check payload.',
-                err.flatten()
+                err.flatten(),
+                { requestId, retryable: false }
             )
         }
 
-        if (err instanceof MediaValidationError) {
-            return sendMediaError(
-                res,
-                err.status,
-                err.code,
-                err.message,
-                err.details
-            )
-        }
-
-        if (typeof (err as { status?: unknown })?.status === 'number') {
-            const status = (err as { status: number }).status
-            const message =
-                err instanceof Error ? err.message : 'Media request failed'
-            const code =
-                status === 404
-                    ? 'media.website_not_found'
-                    : 'media.r2_not_configured'
-
-            return sendMediaError(res, status, code, message)
-        }
+        const knownErrorResponse = sendKnownMediaError(res, err, requestId, {
+            notFound: 'media.website_not_found',
+        })
+        if (knownErrorResponse) return knownErrorResponse
 
         return handleGenericError(err, res)
     }
@@ -243,6 +372,7 @@ const moveCatalogItem = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const requestId = requestIdFor(req)
     try {
         const parsed = moveCatalogItemSchema.parse(req.body)
         const result = await mediaR2Service.moveCatalogItemObject({
@@ -260,29 +390,15 @@ const moveCatalogItem = async (
                 400,
                 'media.invalid_payload',
                 'Invalid media move payload.',
-                err.flatten()
+                err.flatten(),
+                { requestId, retryable: false }
             )
         }
 
-        if (err instanceof MediaValidationError) {
-            return sendMediaError(
-                res,
-                err.status,
-                err.code,
-                err.message,
-                err.details
-            )
-        }
-
-        if (typeof (err as { status?: unknown })?.status === 'number') {
-            const status = (err as { status: number }).status
-            const message =
-                err instanceof Error ? err.message : 'Media request failed'
-            const code =
-                status === 404 ? 'media.not_found' : 'media.r2_not_configured'
-
-            return sendMediaError(res, status, code, message)
-        }
+        const knownErrorResponse = sendKnownMediaError(res, err, requestId, {
+            notFound: 'media.not_found',
+        })
+        if (knownErrorResponse) return knownErrorResponse
 
         return handleGenericError(err, res)
     }
@@ -537,6 +653,10 @@ const createCatalogItem = async (
     req: Request,
     res: Response
 ): Promise<Response> => {
+    const startedAt = Date.now()
+    const requestId = requestIdFor(req)
+    res.set('X-Request-Id', requestId)
+
     try {
         const parsed = createCatalogItemSchema.parse(req.body)
         const item = await mediaCatalogService.createItem({
@@ -554,39 +674,163 @@ const createCatalogItem = async (
             actor: req.mediaAdmin?.email,
         })
 
+        logMediaEvent('info', 'catalog_item_created', {
+            requestId,
+            websiteSlug: req.params.websiteSlug,
+            mediaId: item.id,
+            key: item.key,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+        })
+
         return res.status(201).json(item)
     } catch (err) {
+        logMediaEvent('error', 'catalog_item_create_failed', {
+            requestId,
+            websiteSlug: req.params.websiteSlug,
+            key:
+                typeof (req.body as { key?: unknown })?.key === 'string'
+                    ? (req.body as { key: string }).key
+                    : undefined,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+            error: err instanceof Error ? err.message : err,
+        })
+
         if (err instanceof ZodError) {
             return sendMediaError(
                 res,
                 400,
                 'media.invalid_payload',
                 'Invalid media catalog item payload.',
-                err.flatten()
+                err.flatten(),
+                { requestId, retryable: false }
             )
         }
 
-        if (err instanceof MediaValidationError) {
+        const knownErrorResponse = sendKnownMediaError(res, err, requestId, {
+            notFound: 'media.website_not_found',
+        })
+        if (knownErrorResponse) return knownErrorResponse
+
+        return handleGenericError(err, res)
+    }
+}
+
+const batchCreateCatalogItems = async (
+    req: Request,
+    res: Response
+): Promise<Response> => {
+    const startedAt = Date.now()
+    const requestId = requestIdFor(req)
+    res.set('X-Request-Id', requestId)
+    const requestedCount = Array.isArray((req.body as { items?: unknown })?.items)
+        ? ((req.body as { items: unknown[] }).items.length)
+        : 0
+
+    try {
+        const parsed = batchCreateCatalogItemsSchema.parse(req.body)
+        const items = []
+
+        for (const [index, rawItem] of parsed.items.entries()) {
+            try {
+                const itemInput = createCatalogItemSchema.parse(rawItem)
+                const item = await mediaCatalogService.createItem({
+                    websiteSlug: req.params.websiteSlug,
+                    key: itemInput.key,
+                    filename: itemInput.filename,
+                    src: itemInput.src,
+                    alt: itemInput.alt,
+                    library: itemInput.library,
+                    siteCategory: itemInput.siteCategory,
+                    service: itemInput.service,
+                    subCategory: itemInput.subCategory,
+                    aspectRatio: itemInput.aspectRatio,
+                    sortOrder: itemInput.sortOrder,
+                    actor: req.mediaAdmin?.email,
+                })
+
+                items.push({
+                    index,
+                    key: item.key,
+                    ok: true,
+                    item,
+                })
+            } catch (err) {
+                const error = batchErrorFrom(err, {
+                    notFound: 'media.website_not_found',
+                })
+                const rawKey =
+                    typeof (rawItem as { key?: unknown })?.key === 'string'
+                        ? (rawItem as { key: string }).key
+                        : undefined
+
+                items.push({
+                    index,
+                    ...(rawKey && { key: rawKey }),
+                    ok: false,
+                    error: {
+                        code: error.code,
+                        message: error.message,
+                        status: error.status,
+                        retryable: error.retryable ?? false,
+                        ...(error.details && { details: error.details }),
+                    },
+                })
+            }
+        }
+
+        const succeeded = items.filter(item => item.ok).length
+        const failed = items.length - succeeded
+        const status =
+            failed === 0 ? 'completed' : succeeded > 0 ? 'partial_success' : 'failed'
+
+        logMediaEvent(failed > 0 ? 'warn' : 'info', 'catalog_batch_completed', {
+            requestId,
+            websiteSlug: req.params.websiteSlug,
+            requested: requestedCount,
+            succeeded,
+            failed,
+            status,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+        })
+
+        return res.status(failed > 0 ? 207 : 201).json({
+            request_id: requestId,
+            status,
+            items,
+            summary: {
+                requested: items.length,
+                succeeded,
+                failed,
+            },
+        })
+    } catch (err) {
+        logMediaEvent('error', 'catalog_batch_failed', {
+            requestId,
+            websiteSlug: req.params.websiteSlug,
+            requested: requestedCount,
+            durationMs: Date.now() - startedAt,
+            actor: req.mediaAdmin?.email,
+            error: err instanceof Error ? err.message : err,
+        })
+
+        if (err instanceof ZodError) {
             return sendMediaError(
                 res,
-                err.status,
-                err.code,
-                err.message,
-                err.details
+                400,
+                'media.invalid_payload',
+                `Invalid media catalog batch payload. Upload batches support up to ${mediaUploadBatchMaxItems()} items.`,
+                err.flatten(),
+                { requestId, retryable: false }
             )
         }
 
-        if (typeof (err as { status?: unknown })?.status === 'number') {
-            const status = (err as { status: number }).status
-            const message =
-                err instanceof Error ? err.message : 'Media request failed'
-            const code =
-                status === 404
-                    ? 'media.website_not_found'
-                    : 'media.r2_not_configured'
-
-            return sendMediaError(res, status, code, message)
-        }
+        const knownErrorResponse = sendKnownMediaError(res, err, requestId, {
+            notFound: 'media.website_not_found',
+        })
+        if (knownErrorResponse) return knownErrorResponse
 
         return handleGenericError(err, res)
     }
@@ -727,6 +971,7 @@ export default {
     getAdminPlacements,
     revalidateCatalog,
     createCatalogItem,
+    batchCreateCatalogItems,
     updateCatalogItem,
     batchUpdateCatalogItems,
     assignPlacement,

--- a/src/lib/media-r2.ts
+++ b/src/lib/media-r2.ts
@@ -11,6 +11,9 @@ export type AllowedUploadContentType =
 
 export const DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 export const DEFAULT_PRESIGN_EXPIRES_SECONDS = 15 * 60
+export const DEFAULT_R2_CONNECTION_TIMEOUT_MS = 2_000
+export const DEFAULT_R2_REQUEST_TIMEOUT_MS = 8_000
+export const DEFAULT_MEDIA_UPLOAD_BATCH_MAX_ITEMS = 10
 
 const CONTENT_TYPE_EXTENSIONS: Record<AllowedUploadContentType, string> = {
     'image/jpeg': 'jpg',
@@ -36,6 +39,33 @@ export class MediaValidationError extends Error {
     }
 }
 
+export class MediaOperationError extends Error {
+    status: number
+    code: string
+    retryable: boolean
+    details?: Record<string, unknown>
+
+    constructor({
+        status,
+        code,
+        message,
+        retryable,
+        details,
+    }: {
+        status: number
+        code: string
+        message: string
+        retryable: boolean
+        details?: Record<string, unknown>
+    }) {
+        super(message)
+        this.status = status
+        this.code = code
+        this.retryable = retryable
+        this.details = details
+    }
+}
+
 export const maxUploadBytes = (): number => {
     const parsed = Number(process.env.MEDIA_MAX_UPLOAD_BYTES)
     return Number.isFinite(parsed) && parsed > 0
@@ -43,11 +73,32 @@ export const maxUploadBytes = (): number => {
         : DEFAULT_MAX_UPLOAD_BYTES
 }
 
+export const mediaUploadBatchMaxItems = (): number => {
+    const parsed = Number(process.env.MEDIA_UPLOAD_BATCH_MAX_ITEMS)
+    return Number.isFinite(parsed) && parsed > 0
+        ? Math.floor(parsed)
+        : DEFAULT_MEDIA_UPLOAD_BATCH_MAX_ITEMS
+}
+
 export const presignExpiresSeconds = (): number => {
     const parsed = Number(process.env.R2_PRESIGN_EXPIRES_SECONDS)
     return Number.isFinite(parsed) && parsed > 0
         ? parsed
         : DEFAULT_PRESIGN_EXPIRES_SECONDS
+}
+
+export const r2ConnectionTimeoutMs = (): number => {
+    const parsed = Number(process.env.R2_CONNECTION_TIMEOUT_MS)
+    return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : DEFAULT_R2_CONNECTION_TIMEOUT_MS
+}
+
+export const r2RequestTimeoutMs = (): number => {
+    const parsed = Number(process.env.R2_REQUEST_TIMEOUT_MS)
+    return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : DEFAULT_R2_REQUEST_TIMEOUT_MS
 }
 
 export const isAllowedUploadContentType = (

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -210,6 +210,20 @@ router.post(
 )
 
 router.post(
+    `${BASE_ROUTE}/:websiteSlug/admin/items/batch`,
+    requireMediaAdminSession,
+    [
+        param('websiteSlug')
+            .isString()
+            .trim()
+            .notEmpty()
+            .withMessage('websiteSlug is required'),
+    ],
+    validateRequest,
+    media.batchCreateCatalogItems
+)
+
+router.post(
     `${BASE_ROUTE}/:websiteSlug/admin/items`,
     requireMediaAdminSession,
     [

--- a/src/services/media-r2.ts
+++ b/src/services/media-r2.ts
@@ -7,6 +7,7 @@ import {
     S3Client,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 
 import { COLUMNS, db, Tables } from '../lib/db'
 import {
@@ -18,7 +19,10 @@ import {
     buildR2ObjectKey,
     joinPublicUrl,
     presignExpiresSeconds,
+    r2ConnectionTimeoutMs,
+    r2RequestTimeoutMs,
     validateUploadInput,
+    MediaOperationError,
     MediaValidationError,
 } from '../lib/media-r2'
 import mediaCatalogService, {
@@ -180,12 +184,134 @@ const createR2Client = (): S3Client => {
     return new S3Client({
         region: 'auto',
         endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+        requestHandler: new NodeHttpHandler({
+            connectionTimeout: r2ConnectionTimeoutMs(),
+            requestTimeout: r2RequestTimeoutMs(),
+        }),
         requestChecksumCalculation: 'WHEN_REQUIRED',
         credentials: {
             accessKeyId,
             secretAccessKey,
         },
     })
+}
+
+const providerStatusCode = (err: unknown): number | undefined =>
+    (err as { $metadata?: { httpStatusCode?: number } })?.$metadata
+        ?.httpStatusCode
+
+const providerErrorName = (err: unknown): string | undefined =>
+    (err as { name?: string })?.name
+
+const providerErrorCode = (err: unknown): string | undefined =>
+    (err as { code?: string })?.code
+
+const providerRetryAfter = (err: unknown): string | undefined => {
+    const headers = (err as { $metadata?: { httpHeaders?: Record<string, string> } })
+        ?.$metadata?.httpHeaders
+    return headers?.['retry-after']
+}
+
+const isProviderTimeoutError = (err: unknown): boolean => {
+    const name = providerErrorName(err)
+    const code = providerErrorCode(err)
+    return [
+        'AbortError',
+        'TimeoutError',
+        'RequestTimeout',
+        'RequestTimeoutException',
+    ].includes(name || '') || ['ETIMEDOUT', 'ESOCKETTIMEDOUT'].includes(code || '')
+}
+
+const isProviderBusyError = (err: unknown): boolean => {
+    const statusCode = providerStatusCode(err)
+    const name = providerErrorName(err)
+    return (
+        statusCode === 429 ||
+        statusCode === 503 ||
+        name === 'SlowDown' ||
+        name === 'Throttling' ||
+        name === 'TooManyRequestsException'
+    )
+}
+
+const mapR2OperationError = ({
+    err,
+    operation,
+    key,
+}: {
+    err: unknown
+    operation: string
+    key?: string
+}): never => {
+    const statusCode = providerStatusCode(err)
+    const details: Record<string, unknown> = {
+        provider: 'r2',
+        operation,
+        ...(key && { key }),
+        ...(providerErrorName(err) && { provider_error: providerErrorName(err) }),
+        ...(statusCode && { provider_status: statusCode }),
+    }
+
+    if (isProviderTimeoutError(err)) {
+        throw new MediaOperationError({
+            status: 504,
+            code: 'media.upload_timeout',
+            message: 'Media storage request timed out.',
+            retryable: true,
+            details,
+        })
+    }
+
+    if (isProviderBusyError(err)) {
+        throw new MediaOperationError({
+            status: 503,
+            code: 'media.upload_temporary_unavailable',
+            message: 'Media storage is temporarily busy. Retry this upload shortly.',
+            retryable: true,
+            details: {
+                ...details,
+                ...(providerRetryAfter(err) && {
+                    retry_after: providerRetryAfter(err),
+                }),
+            },
+        })
+    }
+
+    throw new MediaOperationError({
+        status: 502,
+        code: 'media.upload_provider_error',
+        message: 'Media storage provider request failed.',
+        retryable: true,
+        details,
+    })
+}
+
+const sendR2Command = async <T>(
+    client: S3Client,
+    command: any,
+    operation: string,
+    key?: string
+): Promise<T> => {
+    try {
+        return (await client.send(command as never)) as T
+    } catch (err) {
+        const statusCode = providerStatusCode(err)
+        if (
+            statusCode === 404 ||
+            statusCode === 409 ||
+            statusCode === 412 ||
+            providerErrorName(err) === 'NotFound' ||
+            providerErrorName(err) === 'NoSuchKey' ||
+            providerErrorName(err) === 'ConditionalRequestConflict' ||
+            providerErrorName(err) === 'PreconditionFailed'
+        ) {
+            throw err
+        }
+
+        mapR2OperationError({ err, operation, key })
+        throw err
+    }
 }
 
 const normalizePrefix = (prefix?: string): string => {
@@ -306,11 +432,14 @@ const objectExists = async ({
     key: string
 }): Promise<boolean> => {
     try {
-        await client.send(
+        await sendR2Command(
+            client,
             new HeadObjectCommand({
                 Bucket: bucket,
                 Key: key,
-            })
+            }),
+            'head_object',
+            key
         )
         return true
     } catch (err) {
@@ -467,12 +596,23 @@ const listObjects = async ({
           ? `${keyPrefix}/`
           : ''
     const client = createR2Client()
-    const { Contents, IsTruncated } = await client.send(
+    const { Contents, IsTruncated } = await sendR2Command<{
+        Contents?: Array<{
+            Key?: string
+            Size?: number
+            LastModified?: Date
+            ETag?: string
+        }>
+        IsTruncated?: boolean
+    }>(
+        client,
         new ListObjectsV2Command({
             Bucket: config.bucket,
             Prefix: normalizedPrefix || undefined,
             MaxKeys: 1000,
-        })
+        }),
+        'list_objects',
+        normalizedPrefix
     )
 
     if (IsTruncated) {
@@ -623,7 +763,8 @@ const moveCatalogItemObject = async ({
     })
 
     try {
-        await client.send(
+        await sendR2Command(
+            client,
             new CopyObjectCommand({
                 Bucket: config.bucket,
                 Key: scopedDestinationKey,
@@ -631,7 +772,9 @@ const moveCatalogItemObject = async ({
                     item.key
                 ).replace(/%2F/g, '/')}`,
                 IfNoneMatch: '*',
-            })
+            }),
+            'copy_object',
+            scopedDestinationKey
         )
     } catch (err) {
         if (isConditionalWriteFailure(err)) {
@@ -657,11 +800,14 @@ const moveCatalogItemObject = async ({
         })
     } catch (err) {
         try {
-            await client.send(
+            await sendR2Command(
+                client,
                 new DeleteObjectCommand({
                     Bucket: config.bucket,
                     Key: scopedDestinationKey,
-                })
+                }),
+                'delete_object',
+                scopedDestinationKey
             )
         } catch (cleanupErr) {
             console.error(
@@ -675,11 +821,14 @@ const moveCatalogItemObject = async ({
 
     let sourceDeleted = true
     try {
-        await client.send(
+        await sendR2Command(
+            client,
             new DeleteObjectCommand({
                 Bucket: config.bucket,
                 Key: item.key,
-            })
+            }),
+            'delete_object',
+            item.key
         )
     } catch (err) {
         sourceDeleted = false

--- a/test/media-r2-objects.test.ts
+++ b/test/media-r2-objects.test.ts
@@ -220,6 +220,60 @@ describe('media R2 object operations', () => {
         })
     })
 
+    it('maps R2 timeout failures to retryable upload timeout errors', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+        ]
+        mockState.send.mockRejectedValueOnce(
+            Object.assign(new Error('socket timed out'), {
+                name: 'TimeoutError',
+                code: 'ETIMEDOUT',
+            })
+        )
+
+        await expect(
+            mediaR2Service.listObjects({
+                websiteSlug: 'iffers-pictures',
+            })
+        ).rejects.toMatchObject({
+            status: 504,
+            code: 'media.upload_timeout',
+            retryable: true,
+        })
+    })
+
+    it('maps R2 busy failures to retryable temporary unavailable errors', async () => {
+        mockState.queryResults = [
+            { data: websiteRecord, error: null },
+            { data: r2ConfigRecord, error: null },
+            { data: null, error: null },
+        ]
+        mockState.send.mockRejectedValueOnce(
+            Object.assign(new Error('slow down'), {
+                name: 'SlowDown',
+                $metadata: {
+                    httpStatusCode: 503,
+                    httpHeaders: { 'retry-after': '3' },
+                },
+            })
+        )
+
+        await expect(
+            mediaR2Service.checkDestination({
+                websiteSlug: 'iffers-pictures',
+                destinationKey: 'events/baby-shower/new.jpg',
+            })
+        ).rejects.toMatchObject({
+            status: 503,
+            code: 'media.upload_temporary_unavailable',
+            retryable: true,
+            details: expect.objectContaining({
+                retry_after: '3',
+            }),
+        })
+    })
+
     it('checks site image destination paths across catalog and R2', async () => {
         mockState.queryResults = [
             { data: websiteRecord, error: null },
@@ -617,7 +671,13 @@ describe('media R2 object operations', () => {
             })
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 'Failed to delete source R2 object after catalog move: events/baby-shower/source.jpg',
-                deleteError
+                expect.objectContaining({
+                    code: 'media.upload_provider_error',
+                    details: expect.objectContaining({
+                        operation: 'delete_object',
+                        key: 'events/baby-shower/source.jpg',
+                    }),
+                })
             )
         } finally {
             consoleErrorSpy.mockRestore()

--- a/test/media-r2.test.ts
+++ b/test/media-r2.test.ts
@@ -5,14 +5,17 @@ import mediaController from '../src/controllers/media'
 import {
     buildR2ObjectKey,
     joinPublicUrl,
+    MediaOperationError,
     validateUploadInput,
 } from '../src/lib/media-r2'
+import mediaCatalogService from '../src/services/media-catalog'
 import mediaR2Service from '../src/services/media-r2'
 import mediaRevalidationService from '../src/services/media-revalidation'
 
 vi.mock('../src/services/media-r2', () => ({
     default: {
         createPresignedUpload: vi.fn(),
+        checkDestination: vi.fn(),
     },
 }))
 
@@ -59,13 +62,16 @@ const createResponse = () => {
 const createRequest = ({
     params = { websiteSlug: 'iffers-pictures' },
     body = {},
+    headers = {},
 }: {
     params?: Record<string, string>
     body?: unknown
+    headers?: Record<string, string>
 }): Request =>
     ({
         params,
         body,
+        headers,
     }) as unknown as Request
 
 describe('media R2 key and upload validation helpers', () => {
@@ -132,7 +138,9 @@ describe('media R2 key and upload validation helpers', () => {
 describe('media presigned upload controller', () => {
     beforeEach(() => {
         vi.mocked(mediaR2Service.createPresignedUpload).mockReset()
+        vi.mocked(mediaR2Service.checkDestination).mockReset()
         vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockReset()
+        vi.mocked(mediaCatalogService.createItem).mockReset()
         vi.mocked(mediaR2Service.createPresignedUpload).mockResolvedValue({
             presigned_url: 'https://signed.example.test/upload',
             public_url:
@@ -171,6 +179,73 @@ describe('media presigned upload controller', () => {
                 'https://pub.example.test/events/baby-shower/1712345678000-abc123-baby.jpg',
             r2_key: 'events/baby-shower/1712345678000-abc123-baby.jpg',
             expires_at: '2026-05-27T12:00:00.000Z',
+            request_id: expect.any(String),
+        })
+    })
+
+    it('returns a retryable timeout envelope for upload provider timeouts', async () => {
+        vi.mocked(mediaR2Service.createPresignedUpload).mockRejectedValue(
+            new MediaOperationError({
+                status: 504,
+                code: 'media.upload_timeout',
+                message: 'Media storage request timed out.',
+                retryable: true,
+                details: { provider: 'r2', operation: 'presign_upload' },
+            })
+        )
+        const res = createResponse()
+
+        await mediaController.presignUpload(
+            createRequest({
+                headers: { 'x-request-id': 'req-upload-timeout' },
+                body: {
+                    filename: 'Baby.jpg',
+                    content_type: 'image/jpeg',
+                    folder: 'events/baby-shower',
+                    size: 123456,
+                },
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(504)
+        expect(res.json).toHaveBeenCalledWith({
+            error: expect.objectContaining({
+                code: 'media.upload_timeout',
+                request_id: 'req-upload-timeout',
+                retryable: true,
+            }),
+        })
+    })
+
+    it('returns retryable upload codes from destination checks', async () => {
+        vi.mocked(mediaR2Service.checkDestination).mockRejectedValue(
+            new MediaOperationError({
+                status: 503,
+                code: 'media.upload_temporary_unavailable',
+                message: 'Media storage is temporarily busy.',
+                retryable: true,
+            })
+        )
+        const res = createResponse()
+
+        await mediaController.checkDestination(
+            createRequest({
+                headers: { 'x-request-id': 'req-check-busy' },
+                body: {
+                    destination_key: 'events/baby-shower/new.jpg',
+                },
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(503)
+        expect(res.json).toHaveBeenCalledWith({
+            error: expect.objectContaining({
+                code: 'media.upload_temporary_unavailable',
+                request_id: 'req-check-busy',
+                retryable: true,
+            }),
         })
     })
 
@@ -193,9 +268,165 @@ describe('media presigned upload controller', () => {
             expect.objectContaining({
                 error: expect.objectContaining({
                     code: 'media.invalid_payload',
+                    retryable: false,
                 }),
             })
         )
+    })
+})
+
+describe('media catalog upload completion controller', () => {
+    beforeEach(() => {
+        vi.mocked(mediaCatalogService.createItem).mockReset()
+        vi.mocked(mediaCatalogService.createItem).mockResolvedValue({
+            id: 1,
+            key: 'events/baby-shower/one.jpg',
+            filename: 'one.jpg',
+            src: 'https://pub.example.test/events/baby-shower/one.jpg',
+            alt: '',
+            library: 'portfolio',
+            siteCategory: null,
+            service: null,
+            subCategory: null,
+            aspectRatio: null,
+            status: 'draft',
+            sortOrder: 0,
+        })
+    })
+
+    it('creates uploaded catalog drafts as a batch with per-file success', async () => {
+        const res = createResponse()
+
+        await mediaController.batchCreateCatalogItems(
+            createRequest({
+                headers: { 'x-request-id': 'req-batch-success' },
+                body: {
+                    items: [
+                        {
+                            key: 'events/baby-shower/one.jpg',
+                            filename: 'one.jpg',
+                        },
+                    ],
+                },
+            }),
+            res
+        )
+
+        expect(mediaCatalogService.createItem).toHaveBeenCalledWith(
+            expect.objectContaining({
+                websiteSlug: 'iffers-pictures',
+                key: 'events/baby-shower/one.jpg',
+                filename: 'one.jpg',
+            })
+        )
+        expect(res.status).toHaveBeenCalledWith(201)
+        expect(res.json).toHaveBeenCalledWith({
+            request_id: 'req-batch-success',
+            status: 'completed',
+            items: [
+                expect.objectContaining({
+                    index: 0,
+                    key: 'events/baby-shower/one.jpg',
+                    ok: true,
+                }),
+            ],
+            summary: {
+                requested: 1,
+                succeeded: 1,
+                failed: 0,
+            },
+        })
+    })
+
+    it('preserves batch partial success with per-file failure codes', async () => {
+        vi.mocked(mediaCatalogService.createItem)
+            .mockResolvedValueOnce({
+                id: 1,
+                key: 'events/baby-shower/one.jpg',
+                filename: 'one.jpg',
+                src: 'https://pub.example.test/events/baby-shower/one.jpg',
+                alt: '',
+                library: 'portfolio',
+                siteCategory: null,
+                service: null,
+                subCategory: null,
+                aspectRatio: null,
+                status: 'draft',
+                sortOrder: 0,
+            })
+            .mockRejectedValueOnce(
+                new MediaOperationError({
+                    status: 503,
+                    code: 'media.upload_temporary_unavailable',
+                    message: 'Media storage is temporarily busy.',
+                    retryable: true,
+                })
+            )
+        const res = createResponse()
+
+        await mediaController.batchCreateCatalogItems(
+            createRequest({
+                headers: { 'x-request-id': 'req-batch-partial' },
+                body: {
+                    items: [
+                        { key: 'events/baby-shower/one.jpg' },
+                        { key: 'events/baby-shower/two.jpg' },
+                    ],
+                },
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(207)
+        expect(res.json).toHaveBeenCalledWith({
+            request_id: 'req-batch-partial',
+            status: 'partial_success',
+            items: [
+                expect.objectContaining({
+                    index: 0,
+                    key: 'events/baby-shower/one.jpg',
+                    ok: true,
+                }),
+                {
+                    index: 1,
+                    key: 'events/baby-shower/two.jpg',
+                    ok: false,
+                    error: {
+                        code: 'media.upload_temporary_unavailable',
+                        message: 'Media storage is temporarily busy.',
+                        status: 503,
+                        retryable: true,
+                    },
+                },
+            ],
+            summary: {
+                requested: 2,
+                succeeded: 1,
+                failed: 1,
+            },
+        })
+    })
+
+    it('returns the stable media envelope for malformed batch payloads', async () => {
+        const res = createResponse()
+
+        await mediaController.batchCreateCatalogItems(
+            createRequest({
+                headers: { 'x-request-id': 'req-batch-invalid' },
+                body: {},
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({
+            error: expect.objectContaining({
+                code: 'media.invalid_payload',
+                request_id: 'req-batch-invalid',
+                retryable: false,
+            }),
+        })
+        expect(mediaCatalogService.createItem).not.toHaveBeenCalled()
     })
 })
 


### PR DESCRIPTION
## Summary
- Add structured upload request IDs, response headers, and non-sensitive timing logs for presign and catalog draft creation.
- Add retryable R2 timeout/backpressure/provider error mapping with configurable S3 connection/request timeouts.
- Add a protected batch draft-completion endpoint that returns per-file success/failure results so partial uploads do not collapse into one generic timeout.
- Document the upload response contract and add focused controller/service tests.

## Risks / Follow-up
- Browser-to-R2 PUTs still happen outside this server; the frontend must map direct-upload timeouts into the same per-file retry path.
- The new batch endpoint is additive. Existing single-file presign and draft creation remain supported.
- `MEDIA_UPLOAD_BATCH_MAX_ITEMS` defaults to 10 to avoid turning the API into a large synchronous queue.

## Visual QA
- None: server-only API contract changes.

## Logical QA Scenarios
- Request a presigned upload URL and confirm the response includes `request_id` and the `X-Request-Id` header.
- Simulate or observe provider timeout/busy failures and confirm retryable `media.upload_timeout`, `media.upload_temporary_unavailable`, or `media.upload_provider_error` responses.
- Complete a one-file upload through `POST /api/media/:websiteSlug/admin/items` and confirm the draft appears in the admin catalog.
- Complete multiple uploaded files through `POST /api/media/:websiteSlug/admin/items/batch` and confirm successful files are persisted even when another file returns a per-file failure.
- Confirm archive, publish, move, placement, and catalog routes still behave as before.

## QA Checklist
- [ ] Upload one valid image and confirm it creates one draft without a timeout.
- [ ] Upload 2-3 images and confirm any partial failure identifies the specific failed file while successful files remain visible in the media dashboard.
- [ ] Retry only failed files after a retryable error instead of re-uploading successful files.
- [ ] Confirm the UI can display/support-copy from `request_id` for failed upload steps.
- [ ] Confirm no regression to publish/archive/restore behavior after uploaded drafts exist.

## Verification
- `PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:$PATH npm run build`
- `PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:$PATH npm test`
