### PR TITLE
DEV-1022 Add Inquire media placement

### DIFF
--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -218,6 +218,23 @@ assignment state when a slot has an assigned media item.
 
 Response headers include `Cache-Control: no-store`.
 
+The Iffer's Pictures registry includes the Inquire page image slot:
+
+```json
+{
+  "slotKey": "inquire.what_happens_next",
+  "pageLabel": "Inquire",
+  "sectionLabel": "What Happens Next",
+  "description": "Image used beside the What Happens Next steps on the inquire page.",
+  "expectedAspectRatios": ["landscape", "portrait"],
+  "affectedPaths": ["/inquire"],
+  "assignment": null
+}
+```
+
+`assignment` is `null` until a published media item is assigned through the
+same placement mutation endpoint used by homepage slots.
+
 ```json
 {
   "version": 1,

--- a/src/lib/media-placements.ts
+++ b/src/lib/media-placements.ts
@@ -195,6 +195,15 @@ export const IFFERS_MEDIA_PLACEMENT_SLOTS = [
         affectedPaths: ['/investment'],
     },
     {
+        key: 'inquire.what_happens_next',
+        pageLabel: 'Inquire',
+        sectionLabel: 'What Happens Next',
+        description:
+            'Image used beside the What Happens Next steps on the inquire page.',
+        expectedAspectRatios: ['landscape', 'portrait'],
+        affectedPaths: ['/inquire'],
+    },
+    {
         key: 'faq.hero',
         pageLabel: 'FAQ',
         sectionLabel: 'Hero',

--- a/test/media-placements-service.test.ts
+++ b/test/media-placements-service.test.ts
@@ -152,6 +152,10 @@ const newPlacementSlots = [
     },
     { slotKey: 'services.card.portrait', affectedPaths: ['/services'] },
     { slotKey: 'services.card.custom_request', affectedPaths: ['/services'] },
+    {
+        slotKey: 'inquire.what_happens_next',
+        affectedPaths: ['/inquire'],
+    },
 ]
 
 describe('media placements service', () => {
@@ -330,7 +334,7 @@ describe('media placements service', () => {
             websiteSlug: 'iffers-pictures',
         })
 
-        expect(result.slots).toHaveLength(23)
+        expect(result.slots).toHaveLength(24)
         expect(result.slots[0]).toEqual(
             expect.objectContaining({
                 slotKey: 'home.hero',
@@ -367,6 +371,21 @@ describe('media placements service', () => {
                 pageLabel: 'Services',
                 sectionLabel: 'Couples & Engagement Card',
                 affectedPaths: ['/services'],
+                assignment: null,
+            })
+        )
+        expect(
+            result.slots.find(
+                slot => slot.slotKey === 'inquire.what_happens_next'
+            )
+        ).toEqual(
+            expect.objectContaining({
+                pageLabel: 'Inquire',
+                sectionLabel: 'What Happens Next',
+                description:
+                    'Image used beside the What Happens Next steps on the inquire page.',
+                expectedAspectRatios: ['landscape', 'portrait'],
+                affectedPaths: ['/inquire'],
                 assignment: null,
             })
         )

--- a/test/media-placements.test.ts
+++ b/test/media-placements.test.ts
@@ -43,6 +43,7 @@ describe('media placement slot registry', () => {
             'portfolio.hero',
             'investment.hero',
             'investment.detail',
+            'inquire.what_happens_next',
             'faq.hero',
         ])
     })
@@ -104,7 +105,26 @@ describe('media placement slot registry', () => {
         ).toBe(true)
         expect(
             getMediaPlacementSlotsForWebsite(IFFERS_PICTURES_WEBSITE_SLUG)
-        ).toHaveLength(23)
+        ).toHaveLength(24)
+    })
+
+    it('returns metadata for the Inquire page image slot', () => {
+        expect(
+            getMediaPlacementSlot({
+                websiteSlug: IFFERS_PICTURES_WEBSITE_SLUG,
+                slotKey: 'inquire.what_happens_next',
+            })
+        ).toEqual(
+            expect.objectContaining({
+                key: 'inquire.what_happens_next',
+                pageLabel: 'Inquire',
+                sectionLabel: 'What Happens Next',
+                description:
+                    'Image used beside the What Happens Next steps on the inquire page.',
+                expectedAspectRatios: ['landscape', 'portrait'],
+                affectedPaths: ['/inquire'],
+            })
+        )
     })
 
     it('rejects unknown placement slots with a structured media error', () => {


### PR DESCRIPTION
## Summary
- Add the Iffer's Pictures Inquire page image slot to the server media placement registry as `inquire.what_happens_next`.
- Expose admin metadata for the slot with Inquire page grouping, What Happens Next section label, expected landscape/portrait ratios, and `/inquire` revalidation targeting.
- Document the frontend/admin contract and extend placement tests for listing, assignment, clearing, and targeted revalidation behavior.

## Risks / Follow-up
- No database migration is required because the existing `media_placements` table accepts safe slot keys and assignments are created through the existing generic placement endpoint.
- DEV-1023 should consume `inquire.what_happens_next` in the admin dashboard and Inquire page frontend.

## Visual QA
- None for this server-only change; visual validation belongs to DEV-1023 after the frontend consumes the new slot.

## Logical QA
- `GET /api/media/iffers-pictures/admin/placements` includes `inquire.what_happens_next` with `assignment: null` before assignment.
- Assigning a published media item with `PUT /api/media/iffers-pictures/admin/placements/inquire.what_happens_next` returns the slot with assignment metadata.
- `GET /api/media/iffers-pictures/placements` returns the Inquire placement only when the assigned media item is published.
- Replacing or clearing the placement keeps existing homepage/service placements unchanged and targets `/inquire` for revalidation.

## QA Checklist
- Verify the admin placements response shows an Inquire / What Happens Next slot.
- Assign a published image to `inquire.what_happens_next` and confirm the response includes the assigned media.
- Replace the assigned image and confirm the slot updates to the new media.
- Clear the slot and confirm `DELETE` returns `{ "cleared": true, "slotKey": "inquire.what_happens_next" }`.
- Confirm existing Home, About, Services, Investment, Portfolio, and FAQ slots still appear.

## Verification
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build`
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npx vitest run test/media-placements.test.ts test/media-placements-service.test.ts test/media-placements-routes.test.ts`
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test`