### PR TITLE
DEV-1021 Add homepage Image Strip 3 placement

### DIFF
--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -218,7 +218,22 @@ assignment state when a slot has an assigned media item.
 
 Response headers include `Cache-Control: no-store`.
 
-The Iffer's Pictures registry includes the Inquire page image slot:
+The Iffer's Pictures registry includes homepage image strip slots, including
+the third below-hero strip image:
+
+```json
+{
+  "slotKey": "home.strip.3",
+  "pageLabel": "Home",
+  "sectionLabel": "Image Strip 3",
+  "description": "Third supporting image in the homepage image strip.",
+  "expectedAspectRatios": ["portrait", "landscape"],
+  "affectedPaths": ["/"],
+  "assignment": null
+}
+```
+
+The registry also includes the Inquire page image slot:
 
 ```json
 {

--- a/src/lib/media-placements.ts
+++ b/src/lib/media-placements.ts
@@ -40,6 +40,14 @@ export const IFFERS_MEDIA_PLACEMENT_SLOTS = [
         affectedPaths: ['/'],
     },
     {
+        key: 'home.strip.3',
+        pageLabel: 'Home',
+        sectionLabel: 'Image Strip 3',
+        description: 'Third supporting image in the homepage image strip.',
+        expectedAspectRatios: ['portrait', 'landscape'],
+        affectedPaths: ['/'],
+    },
+    {
         key: 'home.meet_jenn',
         pageLabel: 'Home',
         sectionLabel: 'Meet Jenn',

--- a/test/media-placements-routes.test.ts
+++ b/test/media-placements-routes.test.ts
@@ -163,7 +163,9 @@ describe('media placement route coverage', () => {
     beforeEach(() => {
         vi.mocked(mediaCatalogService.batchUpdateItems).mockReset()
         vi.mocked(mediaPlacementsService.listPublicPlacements).mockReset()
+        vi.mocked(mediaPlacementsService.listAdminPlacements).mockReset()
         vi.mocked(mediaPlacementsService.assignPlacement).mockReset()
+        vi.mocked(mediaPlacementsService.clearPlacement).mockReset()
         vi.mocked(mediaRevalidationService.publicCatalogCacheControl).mockReset()
         vi.mocked(mediaRevalidationService.triggerMediaRevalidation).mockReset()
         vi.mocked(mediaRevalidationService.publicCatalogCacheControl).mockReturnValue(
@@ -341,7 +343,7 @@ describe('media placement route coverage', () => {
             publicBaseUrl: 'https://media.ifferspictures.com',
             placements: [
                 {
-                    slotKey: 'home.hero',
+                    slotKey: 'home.strip.3',
                     media: {
                         id: 1,
                         key: 'events/baby-shower/baby.jpg',
@@ -376,7 +378,7 @@ describe('media placement route coverage', () => {
             expect.objectContaining({
                 placements: [
                     expect.objectContaining({
-                        slotKey: 'home.hero',
+                        slotKey: 'home.strip.3',
                         media: expect.objectContaining({
                             id: 1,
                             subCategory: 'Baby Shower',
@@ -389,12 +391,62 @@ describe('media placement route coverage', () => {
         )
     })
 
+    it('returns Image Strip 3 in admin placement listing responses', async () => {
+        vi.mocked(mediaPlacementsService.listAdminPlacements).mockResolvedValue({
+            version: 1,
+            publicBaseUrl: 'https://media.ifferspictures.com',
+            slots: [
+                {
+                    slotKey: 'home.strip.3',
+                    pageLabel: 'Home',
+                    sectionLabel: 'Image Strip 3',
+                    description:
+                        'Third supporting image in the homepage image strip.',
+                    expectedAspectRatios: ['portrait', 'landscape'],
+                    affectedPaths: ['/'],
+                    assignment: null,
+                },
+            ],
+        })
+        const req = createRequest({})
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'get',
+            path: '/api/media/:websiteSlug/admin/placements',
+        })
+
+        await runHandlers(handlers.slice(1), req, res)
+
+        expect(res.statusCode).toBe(200)
+        expect(res.headers['cache-control']).toBe('no-store')
+        expect(mediaPlacementsService.listAdminPlacements).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+        })
+        expect(res.payload).toEqual(
+            expect.objectContaining({
+                slots: [
+                    expect.objectContaining({
+                        slotKey: 'home.strip.3',
+                        pageLabel: 'Home',
+                        sectionLabel: 'Image Strip 3',
+                        description:
+                            'Third supporting image in the homepage image strip.',
+                        expectedAspectRatios: ['portrait', 'landscape'],
+                        affectedPaths: ['/'],
+                        assignment: null,
+                    }),
+                ],
+            })
+        )
+    })
+
     it('passes authenticated admin actor context to placement assignment controller', async () => {
         vi.mocked(mediaPlacementsService.assignPlacement).mockResolvedValue({
-            slotKey: 'home.hero',
+            slotKey: 'home.strip.3',
             pageLabel: 'Home',
-            sectionLabel: 'Hero',
-            description: 'Primary homepage hero image.',
+            sectionLabel: 'Image Strip 3',
+            description: 'Third supporting image in the homepage image strip.',
+            expectedAspectRatios: ['portrait', 'landscape'],
             affectedPaths: ['/'],
             assignment: {
                 id: 10,
@@ -417,7 +469,7 @@ describe('media placement route coverage', () => {
         const req = createRequest({
             params: {
                 websiteSlug: 'iffers-pictures',
-                slotKey: 'home.hero',
+                slotKey: 'home.strip.3',
             },
             body: { media_id: 1 },
         })
@@ -437,9 +489,53 @@ describe('media placement route coverage', () => {
         expect(res.statusCode).toBe(200)
         expect(mediaPlacementsService.assignPlacement).toHaveBeenCalledWith({
             websiteSlug: 'iffers-pictures',
-            slotKey: 'home.hero',
+            slotKey: 'home.strip.3',
             mediaId: 1,
             actor: 'jenn@example.com',
+        })
+        expect(res.payload).toEqual(
+            expect.objectContaining({
+                slotKey: 'home.strip.3',
+                sectionLabel: 'Image Strip 3',
+                expectedAspectRatios: ['portrait', 'landscape'],
+                affectedPaths: ['/'],
+            })
+        )
+    })
+
+    it('passes authenticated admin actor context to placement clearing controller', async () => {
+        vi.mocked(mediaPlacementsService.clearPlacement).mockResolvedValue({
+            cleared: true,
+            slotKey: 'home.strip.3',
+        })
+        const req = createRequest({
+            params: {
+                websiteSlug: 'iffers-pictures',
+                slotKey: 'home.strip.3',
+            },
+        })
+        req.mediaAdmin = {
+            email: 'jenn@example.com',
+            sessionId: 'session-1',
+            expiresAt: '2099-01-01T00:00:00.000Z',
+        }
+        const res = createResponse()
+        const handlers = routeHandlers({
+            method: 'delete',
+            path: '/api/media/:websiteSlug/admin/placements/:slotKey',
+        })
+
+        await runHandlers(handlers.slice(1), req, res)
+
+        expect(res.statusCode).toBe(200)
+        expect(mediaPlacementsService.clearPlacement).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.strip.3',
+            actor: 'jenn@example.com',
+        })
+        expect(res.payload).toEqual({
+            cleared: true,
+            slotKey: 'home.strip.3',
         })
     })
 

--- a/test/media-placements-service.test.ts
+++ b/test/media-placements-service.test.ts
@@ -188,11 +188,20 @@ describe('media placements service', () => {
                     placement,
                     { ...placement, id: 11, slot_key: 'home.strip.1', media_id: 2 },
                     { ...placement, id: 12, slot_key: 'home.strip.2', media_id: 3 },
-                    { ...placement, id: 13, slot_key: 'legacy.hero', media_id: 1 },
+                    { ...placement, id: 13, slot_key: 'home.strip.3', media_id: 4 },
+                    { ...placement, id: 14, slot_key: 'legacy.hero', media_id: 1 },
                 ],
                 error: null,
             },
-            { data: [publishedMedia, draftMedia, archivedMedia], error: null },
+            {
+                data: [
+                    publishedMedia,
+                    draftMedia,
+                    archivedMedia,
+                    publishedSiteMedia,
+                ],
+                error: null,
+            },
         ]
 
         const result = await mediaPlacementsService.listPublicPlacements({
@@ -219,9 +228,27 @@ describe('media placements service', () => {
                         status: 'published',
                     },
                 },
+                {
+                    slotKey: 'home.strip.3',
+                    media: {
+                        id: 4,
+                        key: 'site/about/jenn-portrait.jpg',
+                        filename: 'jenn-portrait.jpg',
+                        src: 'https://media.ifferspictures.com/site/about/jenn-portrait.jpg',
+                        alt: 'Jenn portrait for the about page',
+                        library: 'site',
+                        siteCategory: 'About',
+                        service: null,
+                        subCategory: null,
+                        aspectRatio: 'portrait',
+                        status: 'published',
+                    },
+                },
             ],
         })
-        expect(mockState.builders[3].in).toHaveBeenCalledWith('id', [1, 2, 3])
+        expect(mockState.builders[3].in).toHaveBeenCalledWith('id', [
+            1, 2, 3, 4,
+        ])
     })
 
     it('returns published site media through public placement assignments', async () => {
@@ -334,7 +361,7 @@ describe('media placements service', () => {
             websiteSlug: 'iffers-pictures',
         })
 
-        expect(result.slots).toHaveLength(24)
+        expect(result.slots).toHaveLength(25)
         expect(result.slots[0]).toEqual(
             expect.objectContaining({
                 slotKey: 'home.hero',
@@ -351,6 +378,19 @@ describe('media placements service', () => {
         )
         expect(result.slots.find(slot => slot.slotKey === 'faq.hero')).toEqual(
             expect.objectContaining({ assignment: null })
+        )
+        expect(
+            result.slots.find(slot => slot.slotKey === 'home.strip.3')
+        ).toEqual(
+            expect.objectContaining({
+                pageLabel: 'Home',
+                sectionLabel: 'Image Strip 3',
+                description:
+                    'Third supporting image in the homepage image strip.',
+                expectedAspectRatios: ['portrait', 'landscape'],
+                affectedPaths: ['/'],
+                assignment: null,
+            })
         )
         expect(
             result.slots.find(slot => slot.slotKey === 'about.beyond_camera')
@@ -429,6 +469,59 @@ describe('media placements service', () => {
                 mediaKey: 'events/baby-shower/baby.jpg',
             }),
         })
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_assigned',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            actor: 'jenn@example.com',
+            affectedPaths: ['/'],
+        })
+    })
+
+    it('assigns published portrait media to the homepage Image Strip 3 placement', async () => {
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: publishedMedia, error: null },
+            { data: null, error: null },
+            {
+                data: { ...placement, slot_key: 'home.strip.3' },
+                error: null,
+            },
+        ]
+
+        const result = await mediaPlacementsService.assignPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.strip.3',
+            mediaId: 1,
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.builders[3].insert).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            slot_key: 'home.strip.3',
+            media_id: 1,
+            updated_by: 'jenn@example.com',
+        })
+        expect(result).toEqual(
+            expect.objectContaining({
+                slotKey: 'home.strip.3',
+                pageLabel: 'Home',
+                sectionLabel: 'Image Strip 3',
+                description:
+                    'Third supporting image in the homepage image strip.',
+                expectedAspectRatios: ['portrait', 'landscape'],
+                affectedPaths: ['/'],
+                assignment: expect.objectContaining({
+                    media: expect.objectContaining({
+                        id: 1,
+                        aspectRatio: 'portrait',
+                        status: 'published',
+                    }),
+                }),
+            })
+        )
         expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
             websiteSlug: 'iffers-pictures',
             reason: 'placement_assigned',
@@ -574,6 +667,80 @@ describe('media placements service', () => {
             reason: 'placement_replaced',
             mediaId: 4,
             mediaKey: 'events/replacement.jpg',
+            actor: 'jenn@example.com',
+            affectedPaths: ['/'],
+        })
+    })
+
+    it('replaces the homepage Image Strip 3 placement with published landscape media', async () => {
+        const currentPlacement = { ...placement, slot_key: 'home.strip.3' }
+        const replacementMedia = {
+            ...publishedMedia,
+            id: 5,
+            key: 'events/strip-landscape.jpg',
+            filename: 'strip-landscape.jpg',
+            src: 'https://media.ifferspictures.com/events/strip-landscape.jpg',
+            aspect_ratio: 'landscape',
+        }
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: replacementMedia, error: null },
+            { data: currentPlacement, error: null },
+            { data: publishedMedia, error: null },
+            {
+                data: {
+                    ...currentPlacement,
+                    media_id: 5,
+                },
+                error: null,
+            },
+        ]
+
+        const result = await mediaPlacementsService.assignPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.strip.3',
+            mediaId: 5,
+            actor: 'jenn@example.com',
+        })
+
+        expect(mockState.builders[4].update).toHaveBeenCalledWith({
+            website_id: 'website-1',
+            client_id: 'client-1',
+            slot_key: 'home.strip.3',
+            media_id: 5,
+            updated_by: 'jenn@example.com',
+        })
+        expect(result.assignment?.media).toEqual(
+            expect.objectContaining({
+                id: 5,
+                aspectRatio: 'landscape',
+                status: 'published',
+            })
+        )
+        expect(mediaAuditService.tryCreateLog).toHaveBeenCalledWith({
+            websiteId: 'website-1',
+            clientId: 'client-1',
+            mediaId: 5,
+            mediaKey: 'events/strip-landscape.jpg',
+            action: 'placement_replaced',
+            actor: 'jenn@example.com',
+            oldValues: expect.objectContaining({
+                slotKey: 'home.strip.3',
+                mediaId: 1,
+                mediaKey: 'events/baby-shower/baby.jpg',
+            }),
+            newValues: expect.objectContaining({
+                slotKey: 'home.strip.3',
+                mediaId: 5,
+                mediaKey: 'events/strip-landscape.jpg',
+                aspectRatio: 'landscape',
+            }),
+        })
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_replaced',
+            mediaId: 5,
+            mediaKey: 'events/strip-landscape.jpg',
             actor: 'jenn@example.com',
             affectedPaths: ['/'],
         })
@@ -746,6 +913,50 @@ describe('media placements service', () => {
             mediaId: 1,
             mediaKey: 'events/baby-shower/baby.jpg',
             actor: undefined,
+            affectedPaths: ['/'],
+        })
+    })
+
+    it('clears only the homepage Image Strip 3 placement assignment', async () => {
+        const stripThreePlacement = {
+            ...placement,
+            id: 33,
+            slot_key: 'home.strip.3',
+        }
+        mockState.queryResults = [
+            { data: website, error: null },
+            { data: stripThreePlacement, error: null },
+            { data: publishedMedia, error: null },
+            { data: null, error: null },
+        ]
+
+        const result = await mediaPlacementsService.clearPlacement({
+            websiteSlug: 'iffers-pictures',
+            slotKey: 'home.strip.3',
+            actor: 'jenn@example.com',
+        })
+
+        expect(result).toEqual({ cleared: true, slotKey: 'home.strip.3' })
+        expect(mockState.builders[3].delete).toHaveBeenCalled()
+        expect(mockState.builders[3].eq).toHaveBeenCalledWith('id', 33)
+        expect(mediaAuditService.tryCreateLog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'placement_cleared',
+                actor: 'jenn@example.com',
+                oldValues: expect.objectContaining({
+                    slotKey: 'home.strip.3',
+                    placementId: 33,
+                    mediaId: 1,
+                }),
+                newValues: null,
+            })
+        )
+        expect(tryTriggerMediaRevalidation).toHaveBeenCalledWith({
+            websiteSlug: 'iffers-pictures',
+            reason: 'placement_cleared',
+            mediaId: 1,
+            mediaKey: 'events/baby-shower/baby.jpg',
+            actor: 'jenn@example.com',
             affectedPaths: ['/'],
         })
     })

--- a/test/media-placements.test.ts
+++ b/test/media-placements.test.ts
@@ -24,6 +24,7 @@ describe('media placement slot registry', () => {
             'home.hero',
             'home.strip.1',
             'home.strip.2',
+            'home.strip.3',
             'home.meet_jenn',
             'home.quote_image',
             'about.hero',
@@ -105,7 +106,26 @@ describe('media placement slot registry', () => {
         ).toBe(true)
         expect(
             getMediaPlacementSlotsForWebsite(IFFERS_PICTURES_WEBSITE_SLUG)
-        ).toHaveLength(24)
+        ).toHaveLength(25)
+    })
+
+    it('returns metadata for all homepage image strip slots', () => {
+        expect(
+            getMediaPlacementSlot({
+                websiteSlug: IFFERS_PICTURES_WEBSITE_SLUG,
+                slotKey: 'home.strip.3',
+            })
+        ).toEqual(
+            expect.objectContaining({
+                key: 'home.strip.3',
+                pageLabel: 'Home',
+                sectionLabel: 'Image Strip 3',
+                description:
+                    'Third supporting image in the homepage image strip.',
+                expectedAspectRatios: ['portrait', 'landscape'],
+                affectedPaths: ['/'],
+            })
+        )
     })
 
     it('returns metadata for the Inquire page image slot', () => {


### PR DESCRIPTION
## Summary

- Adds the missing `home.strip.3` media placement contract for Iffers homepage Image Strip 3.
- Keeps the slot metadata aligned with Image Strip 1 and Image Strip 2: Home section, portrait/landscape support, and `/` revalidation targeting.
- Updates registry, service, and route tests so admin listing, assignment, replacement, clearing, public reads, and unknown-slot behavior cover the third strip slot.
- Documents the `home.strip.3` registry contract in `docs/media-api.md`.

## Risks / Follow-Up

- Frontend must consume `home.strip.3` for the third homepage strip image; this server PR exposes and validates the slot.
- No database migration is required because the slot key matches the existing safe key pattern and placement rows are data-driven.

## Verification

- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test -- media-placements`
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build`
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test`

## Visual QA Scenarios

- Admin media dashboard shows `Image Strip 3` under the `HOME` section with the same visual treatment, actions, tags, and empty state as `Image Strip 1` and `Image Strip 2`.
- Public homepage third image in the below-hero strip updates after assigning or replacing `Image Strip 3`.

## Logical QA Scenarios

- Assign a published media item to `home.strip.3` and confirm the public placements API returns it.
- Replace the `home.strip.3` assignment and confirm only the third strip slot changes.
- Clear `home.strip.3` and confirm `home.strip.1`, `home.strip.2`, `home.hero`, `home.meet_jenn`, and `home.quote_image` remain unchanged.
- Confirm homepage revalidation targets `/` when `home.strip.3` changes.

## QA Checklist

- Open `/admin/media` for Iffers and verify `HOME` includes `Image Strip 3`.
- Assign media to `Image Strip 3`.
- Load the public homepage and verify the third below-hero strip image changed.
- Replace the assignment and verify the third strip image changes again.
- Clear the assignment and verify only the third strip slot is cleared.
