### PR TITLE
DEV-1028 Raise admin media upload limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,7 @@ BLAST_SECRET=your-secret-here
 # Media manager observability (optional)
 # Logs a warning when media catalog mutation DB calls exceed this threshold.
 MEDIA_DB_LATENCY_WARN_MS=1000
+
+# Media manager uploads (optional)
+# Defaults to 25 MB.
+MEDIA_MAX_UPLOAD_BYTES=26214400

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ All routes use JSON bodies and respond with JSON. Reuse `validateRequest` when a
 | `R2_PRESIGN_EXPIRES_SECONDS` | Optional R2 presigned upload expiry; defaults to 900 seconds. |
 | `R2_CONNECTION_TIMEOUT_MS` | Optional R2 S3 connection timeout; defaults to 2000ms. |
 | `R2_REQUEST_TIMEOUT_MS` | Optional R2 S3 request timeout; defaults to 8000ms. |
-| `MEDIA_MAX_UPLOAD_BYTES` | Optional maximum media upload size; defaults to 10MB. |
+| `MEDIA_MAX_UPLOAD_BYTES` | Optional maximum media upload size; defaults to 25MB. |
 | `MEDIA_UPLOAD_BATCH_MAX_ITEMS` | Optional maximum batch draft-completion item count; defaults to 10. |
 | `MEDIA_DB_LATENCY_WARN_MS` | Optional Supabase media mutation DB latency warning threshold; defaults to 1000ms. |
 | `MEDIA_ADMIN_EMAILS` | Comma-separated approved media manager admin email addresses. |

--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -321,7 +321,8 @@ Response:
 `POST /api/media/:websiteSlug/admin/uploads/presign`
 
 Protected. Creates a short-lived direct-upload URL for R2. Uploads default to
-draft only after the frontend creates the catalog item.
+draft only after the frontend creates the catalog item. The default maximum file
+size is 25 MB and can be overridden with `MEDIA_MAX_UPLOAD_BYTES`.
 
 Request:
 
@@ -812,7 +813,7 @@ Server runtime:
 | `R2_PRESIGN_EXPIRES_SECONDS` | no | Presign expiry. Defaults to `900`. |
 | `R2_CONNECTION_TIMEOUT_MS` | no | R2 S3 connection timeout. Defaults to `2000`. |
 | `R2_REQUEST_TIMEOUT_MS` | no | R2 S3 request timeout. Defaults to `8000`. |
-| `MEDIA_MAX_UPLOAD_BYTES` | no | Max upload size. Defaults to 10 MB. |
+| `MEDIA_MAX_UPLOAD_BYTES` | no | Max upload size. Defaults to 25 MB. |
 | `MEDIA_UPLOAD_BATCH_MAX_ITEMS` | no | Max batch draft-completion items. Defaults to `10`. |
 | `MEDIA_DB_LATENCY_WARN_MS` | no | Supabase media mutation DB latency warning threshold. Defaults to `1000`. |
 | `MEDIA_REVALIDATION_WEBHOOK_URL` | no | Frontend revalidation webhook. |

--- a/src/lib/media-r2.ts
+++ b/src/lib/media-r2.ts
@@ -9,7 +9,7 @@ export const ALLOWED_UPLOAD_CONTENT_TYPES = [
 export type AllowedUploadContentType =
     (typeof ALLOWED_UPLOAD_CONTENT_TYPES)[number]
 
-export const DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+export const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
 export const DEFAULT_PRESIGN_EXPIRES_SECONDS = 15 * 60
 export const DEFAULT_R2_CONNECTION_TIMEOUT_MS = 2_000
 export const DEFAULT_R2_REQUEST_TIMEOUT_MS = 8_000

--- a/test/media-r2.test.ts
+++ b/test/media-r2.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import mediaController from '../src/controllers/media'
 import {
     buildR2ObjectKey,
+    DEFAULT_MAX_UPLOAD_BYTES,
     joinPublicUrl,
     MediaOperationError,
     validateUploadInput,
@@ -118,6 +119,28 @@ describe('media R2 key and upload validation helpers', () => {
                 size: 1000,
             })
         ).toThrow('Unsupported upload content type.')
+    })
+
+    it('accepts the default 25 MB upload limit', () => {
+        delete process.env.MEDIA_MAX_UPLOAD_BYTES
+
+        expect(
+            validateUploadInput({
+                contentType: 'image/jpeg',
+                size: DEFAULT_MAX_UPLOAD_BYTES,
+            })
+        ).toBe('image/jpeg')
+    })
+
+    it('rejects uploads one byte over the default 25 MB limit', () => {
+        delete process.env.MEDIA_MAX_UPLOAD_BYTES
+
+        expect(() =>
+            validateUploadInput({
+                contentType: 'image/jpeg',
+                size: DEFAULT_MAX_UPLOAD_BYTES + 1,
+            })
+        ).toThrow('Upload exceeds the configured maximum size.')
     })
 
     it('rejects oversized uploads', () => {


### PR DESCRIPTION
## Summary
- raise the default server-side admin media upload cap from 10 MB to 25 MB
- keep JPEG/JPG, PNG, and WebP content-type validation unchanged
- document the 25 MB default and MEDIA_MAX_UPLOAD_BYTES override in server docs and env example
- add boundary tests for exactly 25 MB accepted and one byte over rejected

## Contract / rollout notes
- No schema changes or migrations.
- The existing MEDIA_MAX_UPLOAD_BYTES override still works and can lower or raise the cap if explicitly configured.
- Oversized uploads continue returning the existing media.file_too_large validation error with max_size in details.
- R2 presigned upload requests continue signing content-type and content-length; the accepted content length now follows the 25 MB default server cap.

## Visual QA
Visual QA: none - backend upload validation and documentation only.

## Logical QA
- Presign a JPEG, PNG, or WebP upload with size 26214400 and confirm the server returns a presigned upload response.
- Presign a valid image upload with size 26214401 and confirm the server rejects it with media.file_too_large and max_size=26214400 when no override is configured.
- Confirm unsupported content types such as image/gif still return media.invalid_content_type.
- Confirm draft creation and media metadata behavior are unchanged after a successful direct upload.
- Confirm any frontend upload validation uses the same 25 MB cap before shipping the paired frontend ticket.

## QA Checklist
- [x] npm run build
- [x] env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test
- [x] env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test -- --run test/media-r2.test.ts test/media-r2-service.test.ts
- [ ] Staging smoke: presign and upload a valid image at or near 25 MB
- [ ] Staging smoke: verify a file over 25 MB is rejected with the existing structured error