### PR TITLE
DEV-1032 add FAQ CTA placement slot

### DIFF
--- a/docs/media-api.md
+++ b/docs/media-api.md
@@ -247,6 +247,21 @@ The registry also includes the Inquire page image slot:
 }
 ```
 
+The FAQ page exposes both the hero and bottom CTA image slots. The bottom CTA
+slot appears unassigned until Jen chooses a published image:
+
+```json
+{
+  "slotKey": "faq.cta",
+  "pageLabel": "FAQ",
+  "sectionLabel": "Still Have Questions",
+  "description": "Image paired with the FAQ page bottom CTA.",
+  "expectedAspectRatios": ["portrait", "landscape"],
+  "affectedPaths": ["/faq"],
+  "assignment": null
+}
+```
+
 `assignment` is `null` until a published media item is assigned through the
 same placement mutation endpoint used by homepage slots.
 

--- a/src/lib/media-placements.ts
+++ b/src/lib/media-placements.ts
@@ -219,6 +219,14 @@ export const IFFERS_MEDIA_PLACEMENT_SLOTS = [
         expectedAspectRatios: ['landscape', 'portrait'],
         affectedPaths: ['/faq'],
     },
+    {
+        key: 'faq.cta',
+        pageLabel: 'FAQ',
+        sectionLabel: 'Still Have Questions',
+        description: 'Image paired with the FAQ page bottom CTA.',
+        expectedAspectRatios: ['portrait', 'landscape'],
+        affectedPaths: ['/faq'],
+    },
 ] as const satisfies readonly MediaPlacementSlot[]
 
 export type IffersMediaPlacementSlotKey =

--- a/test/media-placements-service.test.ts
+++ b/test/media-placements-service.test.ts
@@ -156,6 +156,7 @@ const newPlacementSlots = [
         slotKey: 'inquire.what_happens_next',
         affectedPaths: ['/inquire'],
     },
+    { slotKey: 'faq.cta', affectedPaths: ['/faq'] },
 ]
 
 describe('media placements service', () => {
@@ -361,7 +362,7 @@ describe('media placements service', () => {
             websiteSlug: 'iffers-pictures',
         })
 
-        expect(result.slots).toHaveLength(25)
+        expect(result.slots).toHaveLength(26)
         expect(result.slots[0]).toEqual(
             expect.objectContaining({
                 slotKey: 'home.hero',
@@ -426,6 +427,16 @@ describe('media placements service', () => {
                     'Image used beside the What Happens Next steps on the inquire page.',
                 expectedAspectRatios: ['landscape', 'portrait'],
                 affectedPaths: ['/inquire'],
+                assignment: null,
+            })
+        )
+        expect(result.slots.find(slot => slot.slotKey === 'faq.cta')).toEqual(
+            expect.objectContaining({
+                pageLabel: 'FAQ',
+                sectionLabel: 'Still Have Questions',
+                description: 'Image paired with the FAQ page bottom CTA.',
+                expectedAspectRatios: ['portrait', 'landscape'],
+                affectedPaths: ['/faq'],
                 assignment: null,
             })
         )

--- a/test/media-placements.test.ts
+++ b/test/media-placements.test.ts
@@ -46,6 +46,7 @@ describe('media placement slot registry', () => {
             'investment.detail',
             'inquire.what_happens_next',
             'faq.hero',
+            'faq.cta',
         ])
     })
 
@@ -106,7 +107,7 @@ describe('media placement slot registry', () => {
         ).toBe(true)
         expect(
             getMediaPlacementSlotsForWebsite(IFFERS_PICTURES_WEBSITE_SLUG)
-        ).toHaveLength(25)
+        ).toHaveLength(26)
     })
 
     it('returns metadata for all homepage image strip slots', () => {
@@ -143,6 +144,24 @@ describe('media placement slot registry', () => {
                     'Image used beside the What Happens Next steps on the inquire page.',
                 expectedAspectRatios: ['landscape', 'portrait'],
                 affectedPaths: ['/inquire'],
+            })
+        )
+    })
+
+    it('returns metadata for the FAQ bottom CTA image slot', () => {
+        expect(
+            getMediaPlacementSlot({
+                websiteSlug: IFFERS_PICTURES_WEBSITE_SLUG,
+                slotKey: 'faq.cta',
+            })
+        ).toEqual(
+            expect.objectContaining({
+                key: 'faq.cta',
+                pageLabel: 'FAQ',
+                sectionLabel: 'Still Have Questions',
+                description: 'Image paired with the FAQ page bottom CTA.',
+                expectedAspectRatios: ['portrait', 'landscape'],
+                affectedPaths: ['/faq'],
             })
         )
     })


### PR DESCRIPTION
## Summary

- Add the backend `faq.cta` placement slot for Iffers Pictures with FAQ page metadata and `/faq` revalidation targeting.
- Extend placement registry/service tests so `faq.cta` appears unassigned in admin listings and participates in assign/clear revalidation coverage.
- Document the FAQ bottom CTA placement response shape in the media API contract.

## Risks / Rollout Notes

- No database migration is required; `media_placements.slot_key` already stores safe text keys and `faq.cta` matches the existing check.
- This backend PR should ship with the paired Iffers frontend PR so `/faq` consumes the new placement key.

## Paired PR

- Frontend: https://github.com/pixelverse-studios/iffers-pictures/pull/133

## Visual QA Scenarios

- In `/admin/media`, open Placements and filter/select `FAQ`; confirm `Still Have Questions` appears as an editable slot.
- On `/faq`, assign a published image to `faq.cta` and confirm the bottom CTA image changes.
- Clear `faq.cta` and confirm `/faq` falls back to the existing Family pinned image.

## Logical QA Scenarios

- `GET /api/media/iffers-pictures/admin/placements` includes `faq.cta` with `assignment: null` when unassigned.
- `GET /api/media/iffers-pictures/placements` omits unassigned `faq.cta`.
- `PUT /api/media/iffers-pictures/admin/placements/faq.cta` accepts a published media item.
- `DELETE /api/media/iffers-pictures/admin/placements/faq.cta` clears the assignment.
- Assigning/replacing/clearing `faq.cta` targets `/faq` for revalidation.
- Unsupported placement keys still return `media.invalid_placement_slot`.

## QA Checklist

- [ ] Confirm `/admin/media` shows `FAQ` > `Still Have Questions`.
- [ ] Assign a published image to `faq.cta`.
- [ ] Confirm `/faq` shows the assigned bottom CTA image beside "Still Have Questions?".
- [ ] Replace the assigned image and confirm `/faq` updates.
- [ ] Clear the assignment and confirm the original pinned Family fallback returns.
- [ ] Confirm `faq.hero` still works unchanged.
- [ ] Confirm unsupported placement keys are still rejected by the backend.

## Verification

- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test -- media-placements`
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test`
- `env PATH=/Users/phil/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build`
